### PR TITLE
[Fix] postcss.config를 es module 문법으로 변경

### DIFF
--- a/apps/web/postcss.config.js
+++ b/apps/web/postcss.config.js
@@ -1,7 +1,9 @@
-module.exports = {
+const config = {
   plugins: {
     'tailwindcss/nesting': {},
     tailwindcss: {},
     autoprefixer: {},
   },
 };
+
+export default config;


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat] {제목~~} -->
<!-- Reviewer, Assignees, Label 붙이기 -->

## 관련 이슈 번호

<!-- 이슈를 닫지 않는다면 이유 작성하기 -->
close #106 

## 작업 내용
package.json의 "type": "module"설정으로 프로젝트 내 js 파일이 es module로 처리되고 있지만
postcss.config에서 common js 문법으로 작성하여 오류가 나는 상황이었습니다.
따라서 postcss.config를 es module문법으로 수정하였습니다.
