### PR TITLE
[Feat] 티클 생성 API 구현

### DIFF
--- a/apps/api/src/ticle/dto/createTicleDto.ts
+++ b/apps/api/src/ticle/dto/createTicleDto.ts
@@ -1,0 +1,10 @@
+export type CreateTicleDto = {
+  speakerName: string;
+  speakerEmail: string;
+  speakerIntroduce: string;
+  title: string;
+  content: string;
+  startTime: Date;
+  endTime: Date;
+  tags?: string[];
+};

--- a/apps/api/src/ticle/ticle.controller.ts
+++ b/apps/api/src/ticle/ticle.controller.ts
@@ -1,5 +1,6 @@
 import { Body, Controller, Get, Param, Post, Query } from '@nestjs/common';
 
+import { CreateTicleDto } from './dto/createTicleDto';
 import { TicleService } from './ticle.service';
 
 @Controller('ticle')
@@ -24,14 +25,3 @@ export class TicleController {
   @Post(':ticleId/apply')
   applyToTicle(@Param('ticleId') params: any) {}
 }
-
-export type CreateTicleDto = {
-  speakerName: string;
-  speakerEmail: string;
-  speakerIntroduce: string;
-  title: string;
-  content: string;
-  startTime: Date;
-  endTime: Date;
-  tags?: string[];
-};

--- a/apps/api/src/ticle/ticle.controller.ts
+++ b/apps/api/src/ticle/ticle.controller.ts
@@ -1,9 +1,16 @@
-import { Controller, Get, Param, Post, Query } from '@nestjs/common';
+import { Body, Controller, Get, Param, Post, Query } from '@nestjs/common';
+
+import { TicleService } from './ticle.service';
 
 @Controller('ticle')
 export class TicleController {
+  constructor(private readonly ticleService: TicleService) {}
+
   @Post()
-  createTicle() {}
+  async createTicle(@Body() createTicleDto: CreateTicleDto) {
+    const newTicle = await this.ticleService.createTicle(createTicleDto);
+    return newTicle.id;
+  }
 
   @Get(':ticleId')
   getTicle(@Param('ticleId') params: any) {}
@@ -17,3 +24,14 @@ export class TicleController {
   @Post(':ticleId/apply')
   applyToTicle(@Param('ticleId') params: any) {}
 }
+
+export type CreateTicleDto = {
+  speakerName: string;
+  speakerEmail: string;
+  speakerIntroduce: string;
+  title: string;
+  content: string;
+  startTime: Date;
+  endTime: Date;
+  tags?: string[];
+};

--- a/apps/api/src/ticle/ticle.module.ts
+++ b/apps/api/src/ticle/ticle.module.ts
@@ -1,12 +1,17 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
+import { Applicant } from '@/entity/applicant.entity';
+import { Summary } from '@/entity/summary.entity';
+import { Tag } from '@/entity/tag.entity';
 import { Ticle } from '@/entity/ticle.entity';
 
 import { TicleController } from './ticle.controller';
+import { TicleService } from './ticle.service';
 
 @Module({
   controllers: [TicleController],
-  imports: [TypeOrmModule.forFeature([Ticle])],
+  imports: [TypeOrmModule.forFeature([Ticle, Tag, Summary, Applicant])],
+  providers: [TicleService],
 })
 export class TicleModule {}

--- a/apps/api/src/ticle/ticle.service.ts
+++ b/apps/api/src/ticle/ticle.service.ts
@@ -1,0 +1,31 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+
+import { Ticle, TicleStatus } from '@/entity/ticle.entity';
+
+import { CreateTicleDto } from './ticle.controller';
+
+@Injectable()
+export class TicleService {
+  constructor(
+    @InjectRepository(Ticle)
+    private ticleRepository: Repository<Ticle>
+  ) {}
+
+  async createTicle(createTicleDto: CreateTicleDto): Promise<Ticle> {
+    try {
+      const newTicle = this.ticleRepository.create({
+        ...createTicleDto,
+        ticleStatus: TicleStatus.OPEN,
+        applicants: [],
+        summary: null,
+        tags: [],
+      });
+
+      return await this.ticleRepository.save(newTicle);
+    } catch (error) {
+      throw new Error(`Failed to create ticle `);
+    }
+  }
+}

--- a/apps/api/src/ticle/ticle.service.ts
+++ b/apps/api/src/ticle/ticle.service.ts
@@ -4,7 +4,7 @@ import { Repository } from 'typeorm';
 
 import { Ticle, TicleStatus } from '@/entity/ticle.entity';
 
-import { CreateTicleDto } from './ticle.controller';
+import { CreateTicleDto } from './dto/createTicleDto';
 
 @Injectable()
 export class TicleService {

--- a/apps/api/src/ticle/ticle.service.ts
+++ b/apps/api/src/ticle/ticle.service.ts
@@ -24,7 +24,6 @@ export class TicleService {
       const tags = [...existingTags, ...newTags];
       const newTicle = this.ticleRepository.create({
         ...createTicleDto,
-        ticleStatus: TicleStatus.OPEN,
         applicants: [],
         summary: null,
         tags: tags,

--- a/apps/api/src/ticle/ticle.service.ts
+++ b/apps/api/src/ticle/ticle.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 
+import { Tag } from '@/entity/tag.entity';
 import { Ticle, TicleStatus } from '@/entity/ticle.entity';
 
 import { CreateTicleDto } from './dto/createTicleDto';
@@ -10,22 +11,52 @@ import { CreateTicleDto } from './dto/createTicleDto';
 export class TicleService {
   constructor(
     @InjectRepository(Ticle)
-    private ticleRepository: Repository<Ticle>
+    private ticleRepository: Repository<Ticle>,
+    @InjectRepository(Tag)
+    private tagRepository: Repository<Tag>
   ) {}
 
   async createTicle(createTicleDto: CreateTicleDto): Promise<Ticle> {
     try {
+      const tags = await this.checkAndCreateTags(createTicleDto.tags);
       const newTicle = this.ticleRepository.create({
         ...createTicleDto,
         ticleStatus: TicleStatus.OPEN,
         applicants: [],
         summary: null,
-        tags: [],
+        tags: tags,
       });
 
       return await this.ticleRepository.save(newTicle);
     } catch (error) {
       throw new Error(`Failed to create ticle `);
+    }
+  }
+
+  async checkAndCreateTags(tags: string[]): Promise<Tag[]> {
+    try {
+      const foundTags = [];
+      const toCreate = [];
+
+      for (const tagName of tags) {
+        const tag = await this.tagRepository.findOne({ where: { name: tagName } });
+        if (tag) {
+          foundTags.push(tag);
+          continue;
+        }
+        toCreate.push(tagName);
+      }
+
+      for (const tagName of toCreate) {
+        const tag = this.tagRepository.create({
+          name: tagName,
+        });
+        await this.tagRepository.save(tag);
+        foundTags.push(tag);
+      }
+      return foundTags;
+    } catch (error) {
+      throw new Error(`cannot process tag `);
     }
   }
 }


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat] {제목~~} -->
<!-- Reviewer, Assignees, Label 붙이기 -->

## 관련 이슈 번호
- close #13 #19 #28 
<!-- 이슈를 닫지 않는다면 이유 작성하기 -->

## 작업 내용
티클 생성 api를 구현하였습니다. 
이 과정에서 tag 를 붙이기 위하여 tag가 있다면 조회하고, 없다면 생성하는 로직을 추가했습니다. 
티클 생성후 메인이나, 티클 상세페이지로 이동한다고 생각했기에 return 값을 티클의 id값으로 설정했습니다. 
-> api response 바로 만들겠습니다~

## PR 포인트
- tag 로직을 위한 모듈을 만들어야 할지
태그관련 로직은 대부분 티클 생성과 조회에서만 사용됩니다. 따라서 이를 모듈로 분리하는게 맞을지? 고민입니다.
- spread 문법
- api Return 값 

## 고민과 학습내용
## Spread 문법
spread 문법이란 `…Data` 처럼 사용하여 데이터를 매핑하는 문법입니다.

### Spread 문법이 안전하지 않은 이유
1. 얕은 복사
2. 타입 안전성 부족
3. 덮어쓰기 가능
4. 비동기 작업후 참조문제

### 코드 작성 근거

- 유효성 검사는 아직 추가하지 않았지만 `zod` 를 추가할 예정입니다. 이를 이용하여 해결할 수 있을 것이라고 생각합니다.
- 비동기 작업 후 참조 문제는 비동기 작업에서 `데이터의 변경이 일어날 때` 발생합니다. 
예를들어 위의 코드에서는 Tag에 해당하는 작업이 dto를 변경하는 경우가 있습니다. 
또한, spread 문법을 사용하려는 객체가 비동기로 처리되고 resolve 가 되지 않았을 때 발생합니다.
⇒ 현재는 이런일이 없기에 그대로 사용해도 괜찮다고 판단했습니다

## 스크린샷
