### PR TITLE
[Feat] 개설한 티클 가져오기 API 구현

### DIFF
--- a/apps/api/src/dashboard/dashboard.controller.ts
+++ b/apps/api/src/dashboard/dashboard.controller.ts
@@ -1,8 +1,10 @@
 import { Controller, Get, Param, Post } from '@nestjs/common';
 
+import { DashboardService } from './dashboard.service';
+
 @Controller('dashboard')
 export class DashboardController {
-  constructor() {}
+  constructor(private readonly dashboardService: DashboardService) {}
 
   @Get('created')
   getCreatedTicleList() {}

--- a/apps/api/src/dashboard/dashboard.controller.ts
+++ b/apps/api/src/dashboard/dashboard.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Param, Post } from '@nestjs/common';
+import { Body, Controller, Get, Param, Post } from '@nestjs/common';
 
 import { DashboardService } from './dashboard.service';
 
@@ -7,7 +7,9 @@ export class DashboardController {
   constructor(private readonly dashboardService: DashboardService) {}
 
   @Get('created')
-  getCreatedTicleList() {}
+  getCreatedTicleList(@Body() body: { speakerId: number }) {
+    return this.dashboardService.getCreatedTicleList(body.speakerId);
+  }
 
   @Get('applied')
   getAppliedTicleList() {}
@@ -21,3 +23,18 @@ export class DashboardController {
   @Post('applied/:ticleId/join')
   joinTicle(@Param('ticleId') ticleId: number) {}
 }
+
+//select * from application where ticle_id = 1; // 참가자들 목록
+//select * from ticle where author_id = 1; // 내가 만든 티클 목록
+// ticleservice
+//dashboardservice -> (ticleRepository , ApplicantRepository)
+
+//dashboardController(/applied) -> dashboardService에 구현된 getAppliedTicles()  -> ApplicantRepository -> findAllByUserId()
+//dashboardController(/created)->  dashboardService에 구현된 getCreatedTicles()  -> TicleRepository -> findAllByAuthorId()
+
+// domain 이라는 패키지 안에  repository, entity
+// auth -> presentation , domain
+
+// 객체 객체에서 의존관게를 갖는 객체들 -> class 내에 있는field 변수들
+
+//controller -> service -> repository , service

--- a/apps/api/src/dashboard/dashboard.controller.ts
+++ b/apps/api/src/dashboard/dashboard.controller.ts
@@ -6,7 +6,7 @@ import { DashboardService } from './dashboard.service';
 export class DashboardController {
   constructor(private readonly dashboardService: DashboardService) {}
 
-  @Get('created')
+  @Post('created')
   async getCreatedTicleList(@Body() body: { speakerId: number }) {
     return await this.dashboardService.getCreatedTicleList(body.speakerId);
   }

--- a/apps/api/src/dashboard/dashboard.controller.ts
+++ b/apps/api/src/dashboard/dashboard.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, Param, Post } from '@nestjs/common';
+import { Body, Controller, Get, Param, ParseIntPipe, Post, Query } from '@nestjs/common';
 
 import { DashboardService } from './dashboard.service';
 
@@ -6,9 +6,9 @@ import { DashboardService } from './dashboard.service';
 export class DashboardController {
   constructor(private readonly dashboardService: DashboardService) {}
 
-  @Post('created')
-  async getCreatedTicleList(@Body() body: { speakerId: number }) {
-    return await this.dashboardService.getCreatedTicleList(body.speakerId);
+  @Get('created')
+  async getCreatedTicleList(@Query('speakerId', ParseIntPipe) speakerId: number) {
+    return await this.dashboardService.getCreatedTicleList(speakerId);
   }
 
   @Get('applied')

--- a/apps/api/src/dashboard/dashboard.controller.ts
+++ b/apps/api/src/dashboard/dashboard.controller.ts
@@ -7,8 +7,8 @@ export class DashboardController {
   constructor(private readonly dashboardService: DashboardService) {}
 
   @Get('created')
-  getCreatedTicleList(@Body() body: { speakerId: number }) {
-    return this.dashboardService.getCreatedTicleList(body.speakerId);
+  async getCreatedTicleList(@Body() body: { speakerId: number }) {
+    return await this.dashboardService.getCreatedTicleList(body.speakerId);
   }
 
   @Get('applied')
@@ -23,18 +23,3 @@ export class DashboardController {
   @Post('applied/:ticleId/join')
   joinTicle(@Param('ticleId') ticleId: number) {}
 }
-
-//select * from application where ticle_id = 1; // 참가자들 목록
-//select * from ticle where author_id = 1; // 내가 만든 티클 목록
-// ticleservice
-//dashboardservice -> (ticleRepository , ApplicantRepository)
-
-//dashboardController(/applied) -> dashboardService에 구현된 getAppliedTicles()  -> ApplicantRepository -> findAllByUserId()
-//dashboardController(/created)->  dashboardService에 구현된 getCreatedTicles()  -> TicleRepository -> findAllByAuthorId()
-
-// domain 이라는 패키지 안에  repository, entity
-// auth -> presentation , domain
-
-// 객체 객체에서 의존관게를 갖는 객체들 -> class 내에 있는field 변수들
-
-//controller -> service -> repository , service

--- a/apps/api/src/dashboard/dashboard.module.ts
+++ b/apps/api/src/dashboard/dashboard.module.ts
@@ -1,4 +1,10 @@
 import { Module } from '@nestjs/common';
 
-@Module({})
+import { DashboardController } from './dashboard.controller';
+import { DashboardService } from './dashboard.service';
+
+@Module({
+  controllers: [DashboardController],
+  providers: [DashboardService],
+})
 export class DashboardModule {}

--- a/apps/api/src/dashboard/dashboard.service.ts
+++ b/apps/api/src/dashboard/dashboard.service.ts
@@ -1,8 +1,24 @@
-import { Injectable } from '@nestjs/common';
+import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+
+import { Applicant } from '@/entity/applicant.entity';
+import { Ticle } from '@/entity/ticle.entity';
 
 @Injectable()
 export class DashboardService {
-  getCreatedTicleList() {
-    return 'getCreatedTicleList';
+  @InjectRepository(Ticle)
+  private ticleRepository: Repository<Ticle>;
+  @InjectRepository(Applicant)
+  private applicantRepository: Repository<Applicant>;
+
+  async getCreatedTicleList(speakerId: number) {
+    try {
+      return await this.ticleRepository.find({
+        where: { speaker: { id: speakerId } },
+      });
+    } catch (error) {
+      throw new HttpException(`Failed to get created ticle list`, HttpStatus.BAD_REQUEST);
+    }
   }
 }

--- a/apps/api/src/dashboard/dashboard.service.ts
+++ b/apps/api/src/dashboard/dashboard.service.ts
@@ -1,4 +1,4 @@
-import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 
@@ -7,10 +7,12 @@ import { Ticle } from '@/entity/ticle.entity';
 
 @Injectable()
 export class DashboardService {
-  @InjectRepository(Ticle)
-  private ticleRepository: Repository<Ticle>;
-  @InjectRepository(Applicant)
-  private applicantRepository: Repository<Applicant>;
+  constructor(
+    @InjectRepository(Ticle)
+    private readonly ticleRepository: Repository<Ticle>,
+    @InjectRepository(Applicant)
+    private readonly applicantRepository: Repository<Applicant>
+  ) {}
 
   async getCreatedTicleList(speakerId: number) {
     try {
@@ -18,7 +20,7 @@ export class DashboardService {
         where: { speaker: { id: speakerId } },
       });
     } catch (error) {
-      throw new HttpException(`Failed to get created ticle list`, HttpStatus.BAD_REQUEST);
+      throw new BadRequestException('개설한 티클 조회에 실패했습니다.');
     }
   }
 }

--- a/apps/api/src/dashboard/dashboard.service.ts
+++ b/apps/api/src/dashboard/dashboard.service.ts
@@ -1,0 +1,8 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class DashboardService {
+  getCreatedTicleList() {
+    return 'getCreatedTicleList';
+  }
+}


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat] {제목~~} -->
<!-- Reviewer, Assignees, Label 붙이기 -->

## 관련 이슈 번호

<!-- 이슈를 닫지 않는다면 이유 작성하기 -->

- close #80

## 작업 내용
- 개설한 티클 조회하는 api 작성
- dashboard.service.ts 생성 후 티클 리스트 조회하는 메소드 구현
   - 데이터 조회 후 오류 발생하면 400 에러 던지도록 구현

## PR 포인트
- speakeId를 어떻게 넘겨받을까 하다가 body로 받는 것이 나을 것 같아 Get에서 Post로 메소드를 변경했습니다.

## 고민과 학습내용
- speakerId를 쿼리로 받고 Get을 사용할지 고민을 했는데 User와 관련된 정보이므로 body에 넣고, ticleId 같은 것들만 Get 메소드를 통해 쿼리를 보낼 예정이라 메소드를 수정하게 되었습니다. 이와 관련해서 더 좋은 아이디어나 리뷰가 있다면 남겨주시면 감사하겠습니다. 
- 에러 처리 및 repository 분리는 리팩토링 과정에서 수정이 될 예정입니다.
- return 값들에 대해서는 우선은 ticle 전체를 넘긴 다음에 추후 필터가 구현이 된다면 필요한 부분 select하겠습니다!

## 코드 리뷰 반영
- Get메소드로 바꾸고 쿼리를 통해서 id를 넘기도록 수정했습니다.
- common에 내장되어있는 BadRequestException 사용하도록 수정했습니다.
- dashboard.service.ts의 constructor 내부에서 @InjectRepository 데코레이터를 사용해 주입받도록 수정했습니다.

## 스크린샷
