### PR TITLE
[Feat] Ticle 상세조회 구현

### DIFF
--- a/apps/api/src/ticle/dto/ticleDetailDto.ts
+++ b/apps/api/src/ticle/dto/ticleDetailDto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 
-export class CreateTicleDto {
+export class TickleDetailResponseDto {
   @ApiProperty({
     example: '김철수',
     description: '발표자 이름',
@@ -48,7 +48,6 @@ export class CreateTicleDto {
     example: ['React', 'Frontend', 'State Management', 'Nest', 'Web Development'],
     description: '발표 관련 태그',
     type: [String],
-    required: false,
   })
-  tags?: string[];
+  tags: string[];
 }

--- a/apps/api/src/ticle/ticle.controller.ts
+++ b/apps/api/src/ticle/ticle.controller.ts
@@ -1,6 +1,7 @@
 import { Body, Controller, Get, Param, Post, Query } from '@nestjs/common';
 
 import { CreateTicleDto } from './dto/createTicleDto';
+import { TickleDetailResponseDto } from './dto/ticleDetailDto';
 import { TicleService } from './ticle.service';
 
 @Controller('ticle')
@@ -14,7 +15,9 @@ export class TicleController {
   }
 
   @Get(':ticleId')
-  getTicle(@Param('ticleId') params: any) {}
+  getTicle(@Param('ticleId') ticleId: number): Promise<TickleDetailResponseDto> {
+    return this.ticleService.getTicleByTicleId(ticleId);
+  }
 
   @Get('list')
   getTicleList(@Query('filter') filter?: string, @Query('sort') sort?: string) {}

--- a/apps/api/src/ticle/ticle.service.ts
+++ b/apps/api/src/ticle/ticle.service.ts
@@ -1,11 +1,12 @@
-import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
+import { HttpException, HttpStatus, Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { In, Repository } from 'typeorm';
 
 import { Tag } from '@/entity/tag.entity';
-import { Ticle, TicleStatus } from '@/entity/ticle.entity';
+import { Ticle } from '@/entity/ticle.entity';
 
 import { CreateTicleDto } from './dto/createTicleDto';
+import { TickleDetailResponseDto } from './dto/ticleDetailDto';
 
 @Injectable()
 export class TicleService {
@@ -58,5 +59,29 @@ export class TicleService {
 
     const newTags = this.tagRepository.create(tagsToCreate.map((name) => ({ name })));
     return await this.tagRepository.save(newTags);
+  }
+
+  async getTicleByTicleId(ticleId: number): Promise<TickleDetailResponseDto> {
+    const ticle = await this.ticleRepository.findOne({
+      where: { id: ticleId },
+      relations: {
+        tags: true,
+      },
+    });
+
+    if (!ticle) {
+      throw new NotFoundException('티클을 찾을 수 없습니다.');
+    }
+
+    return {
+      speakerName: ticle.speakerName,
+      speakerEmail: ticle.speakerEmail,
+      speakerIntroduce: ticle.speakerIntroduce,
+      title: ticle.title,
+      content: ticle.content,
+      startTime: ticle.startTime,
+      endTime: ticle.endTime,
+      tags: ticle.tags.map((tag) => tag.name),
+    };
   }
 }

--- a/apps/api/src/ticle/ticle.service.ts
+++ b/apps/api/src/ticle/ticle.service.ts
@@ -1,4 +1,4 @@
-import { HttpException, HttpStatus, Injectable, NotFoundException } from '@nestjs/common';
+import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { In, Repository } from 'typeorm';
 
@@ -32,7 +32,7 @@ export class TicleService {
 
       return await this.ticleRepository.save(newTicle);
     } catch (error) {
-      throw new HttpException(`Failed to create ticle `, HttpStatus.BAD_REQUEST);
+      throw new BadRequestException(`Failed to create ticle `);
     }
   }
 

--- a/apps/api/src/ticle/ticle.service.ts
+++ b/apps/api/src/ticle/ticle.service.ts
@@ -72,16 +72,11 @@ export class TicleService {
     if (!ticle) {
       throw new NotFoundException('티클을 찾을 수 없습니다.');
     }
+    const { tags, ...ticleData } = ticle;
 
     return {
-      speakerName: ticle.speakerName,
-      speakerEmail: ticle.speakerEmail,
-      speakerIntroduce: ticle.speakerIntroduce,
-      title: ticle.title,
-      content: ticle.content,
-      startTime: ticle.startTime,
-      endTime: ticle.endTime,
-      tags: ticle.tags.map((tag) => tag.name),
+      ...ticleData,
+      tags: tags.map((tag) => tag.name),
     };
   }
 }


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat] {제목~~} -->
<!-- Reviewer, Assignees, Label 붙이기 -->

## 관련 이슈 번호

<!-- 이슈를 닫지 않는다면 이유 작성하기 -->

- close #145 

## 작업 내용
- ticle 상세조회 구현
- dto 생성

## PR 포인트
- Dto 
- relation 조회 방법

## 고민과 학습내용
db 조회시 typeORM의 option 을 이용하여 연관 관계에 있는 Tag를 불러올 수 있도록 하였습니다. 
현재로서는 불러온 Tag의 정보는 name 만 필요하다고 생각했기에, 상세조회 시 응답으로 Name 만 볼 수 있도록 하였습니다. 

dto를 생성하며 swagger에서 보일 수 있도록 @ApiProperty 를 추가하였습니다. 
또한, dto 파일을 분리함으로서 zod 도입시 dto파일 내부에서 zod 설정을 진행할 수 있을 것 같습니다. 

## 스크린샷
