### PR TITLE
[Feat] 티클 참가 신청 API 구현

### DIFF
--- a/apps/api/config/typeorm.config.ts
+++ b/apps/api/config/typeorm.config.ts
@@ -18,6 +18,8 @@ export class TypeOrmConfigService implements TypeOrmOptionsFactory {
       autoLoadEntities: true,
       synchronize: nodeEnv !== 'production',
       logging: nodeEnv !== 'production',
+      supportBigNumbers: true,
+      bigNumberStrings: false,
     };
   }
 }

--- a/apps/api/src/ticle/dto/ticleDetailDto.ts
+++ b/apps/api/src/ticle/dto/ticleDetailDto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 
-export class CreateTicleDto {
+export class TickleDetailResponseDto {
   @ApiProperty({
     example: '김철수',
     description: '발표자 이름',
@@ -48,7 +48,6 @@ export class CreateTicleDto {
     example: ['React', 'Frontend', 'State Management', 'Nest', 'Web Development'],
     description: '발표 관련 태그',
     type: [String],
-    required: false,
   })
-  tags?: string[];
+  tags: string[];
 }

--- a/apps/api/src/ticle/ticle.controller.ts
+++ b/apps/api/src/ticle/ticle.controller.ts
@@ -1,6 +1,7 @@
 import { Body, Controller, Get, Param, Post, Query } from '@nestjs/common';
 
 import { CreateTicleDto } from './dto/createTicleDto';
+import { TickleDetailResponseDto } from './dto/ticleDetailDto';
 import { TicleService } from './ticle.service';
 
 @Controller('ticle')
@@ -14,7 +15,9 @@ export class TicleController {
   }
 
   @Get(':ticleId')
-  getTicle(@Param('ticleId') params: any) {}
+  getTicle(@Param('ticleId') ticleId: number): Promise<TickleDetailResponseDto> {
+    return this.ticleService.getTicleByTicleId(ticleId);
+  }
 
   @Get('list')
   getTicleList(@Query('filter') filter?: string, @Query('sort') sort?: string) {}

--- a/apps/api/src/ticle/ticle.controller.ts
+++ b/apps/api/src/ticle/ticle.controller.ts
@@ -23,5 +23,7 @@ export class TicleController {
   getTicleSearchList() {}
 
   @Post(':ticleId/apply')
-  applyToTicle(@Param('ticleId') params: any) {}
+  applyToTicle(@Param('ticleId') ticleId: number, @Body() body: { userId: number }) {
+    return this.ticleService.applyTicle(ticleId, body.userId);
+  }
 }

--- a/apps/api/src/ticle/ticle.module.ts
+++ b/apps/api/src/ticle/ticle.module.ts
@@ -5,13 +5,14 @@ import { Applicant } from '@/entity/applicant.entity';
 import { Summary } from '@/entity/summary.entity';
 import { Tag } from '@/entity/tag.entity';
 import { Ticle } from '@/entity/ticle.entity';
+import { User } from '@/entity/user.entity';
 
 import { TicleController } from './ticle.controller';
 import { TicleService } from './ticle.service';
 
 @Module({
   controllers: [TicleController],
-  imports: [TypeOrmModule.forFeature([Ticle, Tag, Summary, Applicant])],
+  imports: [TypeOrmModule.forFeature([Ticle, Tag, Summary, Applicant, User])],
   providers: [TicleService],
 })
 export class TicleModule {}

--- a/apps/api/src/ticle/ticle.service.ts
+++ b/apps/api/src/ticle/ticle.service.ts
@@ -1,11 +1,12 @@
-import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
+import { HttpException, HttpStatus, Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { In, Repository } from 'typeorm';
 
 import { Tag } from '@/entity/tag.entity';
-import { Ticle, TicleStatus } from '@/entity/ticle.entity';
+import { Ticle } from '@/entity/ticle.entity';
 
 import { CreateTicleDto } from './dto/createTicleDto';
+import { TickleDetailResponseDto } from './dto/ticleDetailDto';
 
 @Injectable()
 export class TicleService {
@@ -58,5 +59,29 @@ export class TicleService {
 
     const newTags = this.tagRepository.create(tagsToCreate.map((name) => ({ name })));
     return await this.tagRepository.save(newTags);
+  }
+
+  async getTicleByTicleId(ticleId: number): Promise<TickleDetailResponseDto> {
+    const ticle = await this.ticleRepository.findOne({
+      where: { id: ticleId },
+      relations: {
+        tags: true,
+      },
+    });
+
+    if (!ticle) {
+      throw new NotFoundException('티클을 찾을 수 없습니다.');
+    }
+
+    return {
+      speakerName: ticle.speakerName,
+      speakerEmail: ticle.speakerEmail,
+      speakerIntroduce: ticle.speakerIntroduce,
+      title: ticle.title,
+      content: ticle.content,
+      startTime: ticle.startTime,
+      endTime: ticle.endTime,
+      tags: ticle.tags.map((tag) => tag.name),
+    };
   }
 }

--- a/apps/api/src/ticle/ticle.service.ts
+++ b/apps/api/src/ticle/ticle.service.ts
@@ -69,8 +69,9 @@ export class TicleService {
   async applyTicle(ticleId: number, userId: number) {
     const ticle = await this.getTicleWithSpeakerIdByTicleId(ticleId);
     const user = await this.getUserById(userId);
-
-    await this.throwIfApplierIsSpeaker(ticle.speaker.id, userId);
+    if (ticle.speaker.id === userId) {
+      throw new HttpException('speaker cannot apply their ticle', HttpStatus.BAD_REQUEST);
+    }
     await this.throwIfExistApplicant(ticleId, userId);
 
     const newApplicant = this.applicantRepository.create({
@@ -78,14 +79,7 @@ export class TicleService {
       user,
     });
     await this.applicantRepository.save(newApplicant);
-
     return 'Successfully applied to ticle';
-  }
-
-  async throwIfApplierIsSpeaker(speakerId: number, userId: number): Promise<void> {
-    if (speakerId === userId) {
-      throw new HttpException('speaker cannot apply their ticle', HttpStatus.BAD_REQUEST);
-    }
   }
 
   async throwIfExistApplicant(ticleId: number, userId: number) {

--- a/apps/api/src/ticle/ticle.service.ts
+++ b/apps/api/src/ticle/ticle.service.ts
@@ -64,7 +64,7 @@ export class TicleService {
     }
 
     const newTags = this.tagRepository.create(tagsToCreate.map((name) => ({ name })));
-    return await this.tagRepository.save(newTags);
+    return this.tagRepository.save(newTags);
   }
 
   async applyTicle(ticleId: number, userId: number) {

--- a/apps/api/src/ticle/ticle.service.ts
+++ b/apps/api/src/ticle/ticle.service.ts
@@ -1,10 +1,10 @@
-import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { In, Repository } from 'typeorm';
 
 import { Applicant } from '@/entity/applicant.entity';
 import { Tag } from '@/entity/tag.entity';
-import { Ticle, TicleStatus } from '@/entity/ticle.entity';
+import { Ticle } from '@/entity/ticle.entity';
 import { User } from '@/entity/user.entity';
 
 import { CreateTicleDto } from './dto/createTicleDto';
@@ -37,7 +37,7 @@ export class TicleService {
 
       return await this.ticleRepository.save(newTicle);
     } catch (error) {
-      throw new HttpException(`Failed to create ticle `, HttpStatus.BAD_REQUEST);
+      throw new BadRequestException(`Failed to create ticle `);
     }
   }
 
@@ -70,7 +70,7 @@ export class TicleService {
     const ticle = await this.getTicleWithSpeakerIdByTicleId(ticleId);
     const user = await this.getUserById(userId);
     if (ticle.speaker.id === userId) {
-      throw new HttpException('speaker cannot apply their ticle', HttpStatus.BAD_REQUEST);
+      throw new BadRequestException('speaker cannot apply their ticle');
     }
     await this.throwIfExistApplicant(ticleId, userId);
 
@@ -91,7 +91,7 @@ export class TicleService {
     });
 
     if (existingApplication) {
-      throw new HttpException('already applied to this ticle', HttpStatus.BAD_REQUEST);
+      throw new BadRequestException('already applied to this ticle');
     }
     return;
   }
@@ -109,7 +109,7 @@ export class TicleService {
       },
     });
     if (!ticle) {
-      throw new HttpException(`cannot found ticle`, HttpStatus.NOT_FOUND);
+      throw new NotFoundException(`cannot found ticle`);
     }
     return ticle;
   }
@@ -120,7 +120,7 @@ export class TicleService {
     });
 
     if (!user) {
-      throw new HttpException(`cannot found user`, HttpStatus.NOT_FOUND);
+      throw new NotFoundException(`cannot found user`);
     }
     return user;
   }


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat] {제목~~} -->
<!-- Reviewer, Assignees, Label 붙이기 -->

## 관련 이슈 번호

<!-- 이슈를 닫지 않는다면 이유 작성하기 -->

- close #43 

## 작업 내용
- 티클 참가신청 api 구현
- db config 옵션 추가

## PR 포인트
- 조회쿼리
- db config 옵션 추가

## 고민과 학습내용

### 에러처리 함수 네이밍
`throwIf ~~~` 라는 네이밍을 사용해 보았습니다! 괜찮은가요?

### 조회 쿼리
1. 현재 조회 쿼리가 여러번 사용되고 있는데, 이래도 괜찮은지 의문이 듭니다. 
이미 신청한 사람인지 검증하기 위해서 현재는 `ticle조회`, `user조회` 를 진행한 뒤, 두개의 id를 통해 `applicants` 를 조회하는 총 3개의 쿼리가 발생하고 있습니다. 
이를 `join` 연산으로 `ticle`과 `applicant`를 함께 불러와서 쿼리의 개수를 줄이는 것이 db접근 수를 줄이기 때문에 더 좋지 않나? 라는 생각이 듭니다.

3. 자신이 생성한 티클을 신청하지 못하도록 검증했습니다. 
이 과정에서 speaker의 id가 필요하여 Join 이 발생하는 쿼리를 작성하게 되었습니다. 이때, speaker에 해당하는 user정보는 Id 만 필요하므로 option을 통해 speaker의 id만 조회하도록 최적화?? 하였습니다. 

### Bigint id 조회시 string으로 취급되는 문제
```TypeScript
const ticle = await this.ticleRepository.findOne({
      where: { id: ticleId },
      relations: {
        speaker: true,
      },
    });
```
위와 같이 조회한 speaker의 id가 string으로 가져와 집니다.
이 문제가 발생하는 이유는 bigint가  string으로 변환되어 조회될 가능성이 있다는 것입니다. 

이 문제를 다음과 같은 옵션을 추가해서 number 형식으로 조회될 수 있도록 변경했습니다!

**TypeORM 설정에서 bigint 처리 방식 변경**
```typescript
// TypeORM 설정
{
      …other options
      supportBigNumbers: true,
      bigNumberStrings: false
}
```

## 스크린샷
