### PR TITLE
[Feat] 신청한 티클 가져오기 API 구현

### DIFF
--- a/apps/api/src/dashboard/dashboard.controller.ts
+++ b/apps/api/src/dashboard/dashboard.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, Param, ParseIntPipe, Post, Query } from '@nestjs/common';
+import { Controller, Get, Param, ParseIntPipe, Post, Query } from '@nestjs/common';
 
 import { DashboardService } from './dashboard.service';
 
@@ -12,7 +12,9 @@ export class DashboardController {
   }
 
   @Get('applied')
-  getAppliedTicleList() {}
+  async getAppliedTicleList(@Query('userId', ParseIntPipe) userId: number) {
+    return await this.dashboardService.getAppliedTicleList(userId);
+  }
 
   @Get('created/:ticleId/applicants')
   getParticipants(@Param('ticleId') ticleId: number) {}

--- a/apps/api/src/dashboard/dashboard.module.ts
+++ b/apps/api/src/dashboard/dashboard.module.ts
@@ -2,8 +2,12 @@ import { Module } from '@nestjs/common';
 
 import { DashboardController } from './dashboard.controller';
 import { DashboardService } from './dashboard.service';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Ticle } from '@/entity/ticle.entity';
+import { Applicant } from '@/entity/applicant.entity';
 
 @Module({
+  imports: [TypeOrmModule.forFeature([Ticle, Applicant])],
   controllers: [DashboardController],
   providers: [DashboardService],
 })

--- a/apps/api/src/dashboard/dashboard.module.ts
+++ b/apps/api/src/dashboard/dashboard.module.ts
@@ -1,7 +1,9 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
-import { Ticle } from '@/entity/ticle.entity';
+
 import { Applicant } from '@/entity/applicant.entity';
+import { Ticle } from '@/entity/ticle.entity';
+
 import { DashboardController } from './dashboard.controller';
 import { DashboardService } from './dashboard.service';
 

--- a/apps/api/src/dashboard/dashboard.module.ts
+++ b/apps/api/src/dashboard/dashboard.module.ts
@@ -1,5 +1,4 @@
 import { Module } from '@nestjs/common';
-
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Ticle } from '@/entity/ticle.entity';
 import { Applicant } from '@/entity/applicant.entity';

--- a/apps/api/src/dashboard/dashboard.module.ts
+++ b/apps/api/src/dashboard/dashboard.module.ts
@@ -1,10 +1,10 @@
 import { Module } from '@nestjs/common';
 
-import { DashboardController } from './dashboard.controller';
-import { DashboardService } from './dashboard.service';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Ticle } from '@/entity/ticle.entity';
 import { Applicant } from '@/entity/applicant.entity';
+import { DashboardController } from './dashboard.controller';
+import { DashboardService } from './dashboard.service';
 
 @Module({
   imports: [TypeOrmModule.forFeature([Ticle, Applicant])],

--- a/apps/api/src/dashboard/dashboard.service.ts
+++ b/apps/api/src/dashboard/dashboard.service.ts
@@ -23,4 +23,17 @@ export class DashboardService {
       throw new BadRequestException('개설한 티클 조회에 실패했습니다.');
     }
   }
+
+  async getAppliedTicleList(userId: number) {
+    try {
+      const applicants = await this.applicantRepository.find({
+        where: { user: { id: userId } },
+        relations: ['ticle'],
+      });
+
+      return applicants.map((applicant) => applicant.ticle);
+    } catch (error) {
+      throw new BadRequestException('신청한 티클 조회에 실패했습니다.');
+    }
+  }
 }


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat] {제목~~} -->
<!-- Reviewer, Assignees, Label 붙이기 -->

## 관련 이슈 번호

<!-- 이슈를 닫지 않는다면 이유 작성하기 -->

- close #72
## 작업 내용
- 신청한 티클 조회하는 api 작성
- 참가한 티클 list를 return하여 ticle에 대한 정보만 받음

## PR 포인트
- applicant 테이블에서 참여자 userId에 해당하는 정보들을 검색 후에 ticle 정보들만 배열로 return 하도록 구현했습니다.

## 고민과 학습내용
- 참여자들의 대한 정보는 추후에 개발할 다른 함수에서 조회해야 해서 getApplieTicleList 함수는 ticle만 관계를 갖도록 하였습니다.
```ts
const applicants = await this.applicantRepository.find({
        where: { user: { id: userId } },
        relations: ['ticle'],
      });
```

- applicants에서 다른 정보 외에 대시보드에서 리스트에 필요한 ticle만 배열로 갖기 위해 map을 사용했습니다.
```ts
return applicants.map((applicant) => applicant.ticle);
``` 

## 스크린샷
