### PR TITLE
[Feat] 티클 목록 조회 구현

### DIFF
--- a/apps/api/config/typeorm.config.ts
+++ b/apps/api/config/typeorm.config.ts
@@ -18,6 +18,8 @@ export class TypeOrmConfigService implements TypeOrmOptionsFactory {
       autoLoadEntities: true,
       synchronize: nodeEnv !== 'production',
       logging: nodeEnv !== 'production',
+      supportBigNumbers: true,
+      bigNumberStrings: false,
     };
   }
 }

--- a/apps/api/src/ticle/dto/getTicleListQueryDto.ts
+++ b/apps/api/src/ticle/dto/getTicleListQueryDto.ts
@@ -1,0 +1,38 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import { SortType } from '../sortType.enum';
+
+export class GetTicleListQueryDto {
+  @ApiProperty({
+    example: 1,
+    description: '페이지 번호',
+    default: 1,
+    required: false,
+  })
+  page?: number = 1;
+
+  @ApiProperty({
+    example: 10,
+    description: '페이지당 항목 수',
+    default: 10,
+    required: false,
+  })
+  pageSize?: number = 10;
+
+  @ApiProperty({
+    example: true,
+    description: '개설되어 있는 티클 여부',
+    default: true,
+    required: false,
+  })
+  isOpen?: boolean = true;
+
+  @ApiProperty({
+    enum: SortType,
+    enumName: 'SortType',
+    description: '정렬 기준 (newest: 최신순, oldest: 오래된순, trending: 참여자 많은순)',
+    default: SortType.NEWEST,
+    required: false,
+  })
+  sort?: SortType = SortType.NEWEST;
+}

--- a/apps/api/src/ticle/dto/ticleDetailDto.ts
+++ b/apps/api/src/ticle/dto/ticleDetailDto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 
-export class CreateTicleDto {
+export class TickleDetailResponseDto {
   @ApiProperty({
     example: '김철수',
     description: '발표자 이름',
@@ -48,7 +48,6 @@ export class CreateTicleDto {
     example: ['React', 'Frontend', 'State Management', 'Nest', 'Web Development'],
     description: '발표 관련 태그',
     type: [String],
-    required: false,
   })
-  tags?: string[];
+  tags: string[];
 }

--- a/apps/api/src/ticle/sortType.enum.ts
+++ b/apps/api/src/ticle/sortType.enum.ts
@@ -1,0 +1,5 @@
+export enum SortType {
+  NEWEST = 'newest',
+  OLDEST = 'oldest',
+  TRENDING = 'trending',
+}

--- a/apps/api/src/ticle/ticle.controller.ts
+++ b/apps/api/src/ticle/ticle.controller.ts
@@ -1,6 +1,7 @@
 import { Body, Controller, Get, Param, Post, Query } from '@nestjs/common';
 
 import { CreateTicleDto } from './dto/createTicleDto';
+import { TickleDetailResponseDto } from './dto/ticleDetailDto';
 import { TicleService } from './ticle.service';
 
 @Controller('ticle')
@@ -14,7 +15,9 @@ export class TicleController {
   }
 
   @Get(':ticleId')
-  getTicle(@Param('ticleId') params: any) {}
+  getTicle(@Param('ticleId') ticleId: number): Promise<TickleDetailResponseDto> {
+    return this.ticleService.getTicleByTicleId(ticleId);
+  }
 
   @Get('list')
   getTicleList(@Query('filter') filter?: string, @Query('sort') sort?: string) {}

--- a/apps/api/src/ticle/ticle.controller.ts
+++ b/apps/api/src/ticle/ticle.controller.ts
@@ -1,7 +1,9 @@
 import { Body, Controller, Get, Param, Post, Query } from '@nestjs/common';
 
 import { CreateTicleDto } from './dto/createTicleDto';
+import { GetTicleListQueryDto } from './dto/getTicleListQueryDto';
 import { TickleDetailResponseDto } from './dto/ticleDetailDto';
+import { SortType } from './sortType.enum';
 import { TicleService } from './ticle.service';
 
 @Controller('ticle')
@@ -14,16 +16,24 @@ export class TicleController {
     return newTicle.id;
   }
 
+  @Get('list')
+  async getTicleList(@Query() query: GetTicleListQueryDto) {
+    const parsedQuery = {
+      page: query.page ? Number(query.page) : 1,
+      pageSize: query.pageSize ? Number(query.pageSize) : 10,
+      isOpen: query.isOpen === undefined ? true : query.isOpen,
+      sort: query.sort || SortType.NEWEST,
+    };
+    return this.ticleService.getTicleList(parsedQuery);
+  }
+
+  @Get('search')
+  getTicleSearchList() {}
+
   @Get(':ticleId')
   getTicle(@Param('ticleId') ticleId: number): Promise<TickleDetailResponseDto> {
     return this.ticleService.getTicleByTicleId(ticleId);
   }
-
-  @Get('list')
-  getTicleList(@Query('filter') filter?: string, @Query('sort') sort?: string) {}
-
-  @Get('search')
-  getTicleSearchList() {}
 
   @Post(':ticleId/apply')
   applyToTicle(@Param('ticleId') ticleId: number, @Body() body: { userId: number }) {

--- a/apps/api/src/ticle/ticle.controller.ts
+++ b/apps/api/src/ticle/ticle.controller.ts
@@ -23,5 +23,7 @@ export class TicleController {
   getTicleSearchList() {}
 
   @Post(':ticleId/apply')
-  applyToTicle(@Param('ticleId') params: any) {}
+  applyToTicle(@Param('ticleId') ticleId: number, @Body() body: { userId: number }) {
+    return this.ticleService.applyTicle(ticleId, body.userId);
+  }
 }

--- a/apps/api/src/ticle/ticle.module.ts
+++ b/apps/api/src/ticle/ticle.module.ts
@@ -5,13 +5,14 @@ import { Applicant } from '@/entity/applicant.entity';
 import { Summary } from '@/entity/summary.entity';
 import { Tag } from '@/entity/tag.entity';
 import { Ticle } from '@/entity/ticle.entity';
+import { User } from '@/entity/user.entity';
 
 import { TicleController } from './ticle.controller';
 import { TicleService } from './ticle.service';
 
 @Module({
   controllers: [TicleController],
-  imports: [TypeOrmModule.forFeature([Ticle, Tag, Summary, Applicant])],
+  imports: [TypeOrmModule.forFeature([Ticle, Tag, Summary, Applicant, User])],
   providers: [TicleService],
 })
 export class TicleModule {}

--- a/apps/api/src/ticle/ticle.service.ts
+++ b/apps/api/src/ticle/ticle.service.ts
@@ -1,11 +1,12 @@
-import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
+import { HttpException, HttpStatus, Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { In, Repository } from 'typeorm';
 
 import { Tag } from '@/entity/tag.entity';
-import { Ticle, TicleStatus } from '@/entity/ticle.entity';
+import { Ticle } from '@/entity/ticle.entity';
 
 import { CreateTicleDto } from './dto/createTicleDto';
+import { TickleDetailResponseDto } from './dto/ticleDetailDto';
 
 @Injectable()
 export class TicleService {
@@ -58,5 +59,29 @@ export class TicleService {
 
     const newTags = this.tagRepository.create(tagsToCreate.map((name) => ({ name })));
     return await this.tagRepository.save(newTags);
+  }
+
+  async getTicleByTicleId(ticleId: number): Promise<TickleDetailResponseDto> {
+    const ticle = await this.ticleRepository.findOne({
+      where: { id: ticleId },
+      relations: {
+        tags: true,
+      },
+    });
+
+    if (!ticle) {
+      throw new NotFoundException('티클을 찾을 수 없습니다.');
+    }
+
+    return {
+      speakerName: ticle.speakerName,
+      speakerEmail: ticle.speakerEmail,
+      speakerIntroduce: ticle.speakerIntroduce,
+      title: ticle.title,
+      content: ticle.content,
+      startTime: ticle.startTime,
+      endTime: ticle.endTime,
+      tags: ticle.tags.map((tag) => tag.name),
+    };
   }
 }

--- a/apps/api/src/ticle/ticle.service.ts
+++ b/apps/api/src/ticle/ticle.service.ts
@@ -174,18 +174,17 @@ export class TicleService {
       .skip(skip)
       .take(pageSize);
 
-    switch (sort) {
-      case SortType.NEWEST:
-        queryBuilder.orderBy('ticle.createdAt', 'DESC');
-        break;
+  switch (sort) {
       case SortType.OLDEST:
         queryBuilder.orderBy('ticle.createdAt', 'ASC');
         break;
       case SortType.TRENDING:
         queryBuilder.orderBy('ticle.applicantsCount', 'DESC');
         break;
+      case SortType.NEWEST:
       default:
         queryBuilder.orderBy('ticle.createdAt', 'DESC');
+}
     }
     const [ticles, totalItems] = await queryBuilder.getManyAndCount();
 

--- a/apps/api/src/ticle/ticle.service.ts
+++ b/apps/api/src/ticle/ticle.service.ts
@@ -197,6 +197,7 @@ export class TicleService {
       endTime: ticle.endTime,
       speakerName: ticle.speakerName,
       applicantsCount: (ticle as any).applicantsCount || 0,
+      createdAt: ticle.createdAt,
     }));
 
     const totalPages = Math.ceil(totalItems / pageSize);

--- a/apps/api/src/ticle/ticle.service.ts
+++ b/apps/api/src/ticle/ticle.service.ts
@@ -4,11 +4,13 @@ import { In, Repository } from 'typeorm';
 
 import { Applicant } from '@/entity/applicant.entity';
 import { Tag } from '@/entity/tag.entity';
-import { Ticle } from '@/entity/ticle.entity';
+import { Ticle, TicleStatus } from '@/entity/ticle.entity';
 import { User } from '@/entity/user.entity';
 
 import { CreateTicleDto } from './dto/createTicleDto';
+import { GetTicleListQueryDto } from './dto/getTicleListQueryDto';
 import { TickleDetailResponseDto } from './dto/ticleDetailDto';
+import { SortType } from './sortType.enum';
 
 @Injectable()
 export class TicleService {
@@ -147,6 +149,67 @@ export class TicleService {
       startTime: ticle.startTime,
       endTime: ticle.endTime,
       tags: ticle.tags.map((tag) => tag.name),
+    };
+  }
+
+  async getTicleList(query: GetTicleListQueryDto) {
+    const { page, pageSize, isOpen, sort } = query;
+    const skip = (page - 1) * pageSize;
+    const queryBuilder = this.ticleRepository
+      .createQueryBuilder('ticle')
+      .select([
+        'ticle.id',
+        'ticle.title',
+        'ticle.startTime',
+        'ticle.endTime',
+        'ticle.speakerName',
+        'ticle.createdAt',
+      ])
+      .where('ticle.ticleStatus = :status', {
+        status: isOpen ? TicleStatus.OPEN : TicleStatus.CLOSED,
+      })
+      .leftJoin('ticle.tags', 'tags')
+      .addSelect('tags.name')
+      .loadRelationCountAndMap('ticle.applicantsCount', 'ticle.applicants')
+      .skip(skip)
+      .take(pageSize);
+
+    switch (sort) {
+      case SortType.NEWEST:
+        queryBuilder.orderBy('ticle.createdAt', 'DESC');
+        break;
+      case SortType.OLDEST:
+        queryBuilder.orderBy('ticle.createdAt', 'ASC');
+        break;
+      case SortType.TRENDING:
+        queryBuilder.orderBy('ticle.applicantsCount', 'DESC');
+        break;
+      default:
+        queryBuilder.orderBy('ticle.createdAt', 'DESC');
+    }
+    const [ticles, totalItems] = await queryBuilder.getManyAndCount();
+
+    const formattedTicles = ticles.map((ticle) => ({
+      id: ticle.id,
+      title: ticle.title,
+      tags: ticle.tags.map((tag) => tag.name),
+      startTime: ticle.startTime,
+      endTime: ticle.endTime,
+      speakerName: ticle.speakerName,
+      applicantsCount: (ticle as any).applicantsCount || 0,
+    }));
+
+    const totalPages = Math.ceil(totalItems / pageSize);
+
+    return {
+      ticles: formattedTicles,
+      meta: {
+        page,
+        take: pageSize,
+        totalItems,
+        totalPages,
+        hasNextPage: page < totalPages,
+      },
     };
   }
 }

--- a/apps/api/src/ticle/ticle.service.ts
+++ b/apps/api/src/ticle/ticle.service.ts
@@ -69,8 +69,9 @@ export class TicleService {
   async applyTicle(ticleId: number, userId: number) {
     const ticle = await this.getTicleWithSpeakerIdByTicleId(ticleId);
     const user = await this.getUserById(userId);
-
-    await this.throwIfApplierIsSpeaker(ticle.speaker.id, userId);
+    if (ticle.speaker.id === userId) {
+      throw new HttpException('speaker cannot apply their ticle', HttpStatus.BAD_REQUEST);
+    }
     await this.throwIfExistApplicant(ticleId, userId);
 
     const newApplicant = this.applicantRepository.create({
@@ -78,14 +79,7 @@ export class TicleService {
       user,
     });
     await this.applicantRepository.save(newApplicant);
-
     return 'Successfully applied to ticle';
-  }
-
-  async throwIfApplierIsSpeaker(speakerId: number, userId: number): Promise<void> {
-    if (speakerId === userId) {
-      throw new HttpException('speaker cannot apply their ticle', HttpStatus.BAD_REQUEST);
-    }
   }
 
   async throwIfExistApplicant(ticleId: number, userId: number) {

--- a/apps/api/src/ticle/ticle.service.ts
+++ b/apps/api/src/ticle/ticle.service.ts
@@ -174,7 +174,7 @@ export class TicleService {
       .skip(skip)
       .take(pageSize);
 
-  switch (sort) {
+    switch (sort) {
       case SortType.OLDEST:
         queryBuilder.orderBy('ticle.createdAt', 'ASC');
         break;
@@ -184,7 +184,6 @@ export class TicleService {
       case SortType.NEWEST:
       default:
         queryBuilder.orderBy('ticle.createdAt', 'DESC');
-}
     }
     const [ticles, totalItems] = await queryBuilder.getManyAndCount();
 

--- a/apps/api/src/ticle/ticle.service.ts
+++ b/apps/api/src/ticle/ticle.service.ts
@@ -1,10 +1,10 @@
-import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { In, Repository } from 'typeorm';
 
 import { Applicant } from '@/entity/applicant.entity';
 import { Tag } from '@/entity/tag.entity';
-import { Ticle, TicleStatus } from '@/entity/ticle.entity';
+import { Ticle } from '@/entity/ticle.entity';
 import { User } from '@/entity/user.entity';
 
 import { CreateTicleDto } from './dto/createTicleDto';
@@ -37,7 +37,7 @@ export class TicleService {
 
       return await this.ticleRepository.save(newTicle);
     } catch (error) {
-      throw new HttpException(`Failed to create ticle `, HttpStatus.BAD_REQUEST);
+      throw new BadRequestException(`Failed to create ticle `);
     }
   }
 
@@ -70,7 +70,7 @@ export class TicleService {
     const ticle = await this.getTicleWithSpeakerIdByTicleId(ticleId);
     const user = await this.getUserById(userId);
     if (ticle.speaker.id === userId) {
-      throw new HttpException('speaker cannot apply their ticle', HttpStatus.BAD_REQUEST);
+      throw new BadRequestException('speaker cannot apply their ticle');
     }
     await this.throwIfExistApplicant(ticleId, userId);
 
@@ -91,7 +91,7 @@ export class TicleService {
     });
 
     if (existingApplication) {
-      throw new HttpException('already applied to this ticle', HttpStatus.BAD_REQUEST);
+      throw new BadRequestException('already applied to this ticle');
     }
     return;
   }
@@ -109,7 +109,7 @@ export class TicleService {
       },
     });
     if (!ticle) {
-      throw new HttpException(`cannot found ticle`, HttpStatus.NOT_FOUND);
+      throw new NotFoundException(`cannot found ticle`);
     }
     return ticle;
   }
@@ -120,7 +120,7 @@ export class TicleService {
     });
 
     if (!user) {
-      throw new HttpException(`cannot found user`, HttpStatus.NOT_FOUND);
+      throw new NotFoundException(`cannot found user`);
     }
     return user;
   }


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat] {제목~~} -->
<!-- Reviewer, Assignees, Label 붙이기 -->

## 관련 이슈 번호

<!-- 이슈를 닫지 않는다면 이유 작성하기 -->

- close #18
- close #19 

## 작업 내용
- 티클 목록 조회 구현

## PR 포인트

## 고민과 학습내용

### query
쿼리를 학습하면서 작성해 보았습니다. 
각각의 옵션을 queryParams로 사용할 수 있습니다. 
- `page` : number - 페이지 번호
- `pageSize` : number - 페이지당 항목 수
- `isOpen`: boolean -  개설 되어있는 티클인지
- `sort` : [`newest`, `oldest`, `trending`] - 최신순, 오래된순, 참가자 많은 순
ex) `/api/ticle/list?page=1&pageSize=5&isOpen=true&sort=newest`


생각보다 어려웠고, TypeORM의 장점도 그다지 느껴지지 않은 것 같습니다. 
현재는 한방쿼리로 작성되어 있는데 query를 여러개로 분리하더라도 가독성을 높이는게 좋을지 잘 모르겠습니다. 

```TypeScript
const queryBuilder = this.ticleRepository
      .createQueryBuilder('ticle')
      .select([
        'ticle.id',
        'ticle.title',
        'ticle.startTime',
        'ticle.endTime',
        'ticle.speakerName',
        'ticle.createdAt',
      ])
      .where('ticle.ticleStatus = :status', {
        status: isOpen ? TicleStatus.OPEN : TicleStatus.CLOSED,
      })
      .leftJoin('ticle.tags', 'tags')
      .addSelect('tags.name')
      .loadRelationCountAndMap('ticle.applicantsCount', 'ticle.applicants')
      .skip(skip)
      .take(pageSize);
```



### 라우팅 문제 트러블 슈팅

목록 조회에 해당하는 정적 라우터 `/list` 가 호출되지 않고, 그 위의 `/:ticleId` 동적 라우터에서 호출되는 상황

```TypeScript
  @Get(':ticleId')
  getTicle(@Param('ticleId') ticleId: number): Promise<TickleDetailResponseDto> {
    return this.ticleService.getTicleByTicleId(ticleId);
  }

  @Get('list')
  async getTicleList() {
    return this.ticleService.getTicleList();
  }
```

### 원인

원인은 정적 라우터보다 동적 라우터를 먼저 선언해서 발생한 것입니다. 
Nest의 라우팅 방식은 express를 기반으로 합니다. 선언된 순서대로 매칭되고, 동적 파라미터는 어떤 형식이든 가능합니다. 
따라서 위의 코드의 `list` 는 ticleId 로 인식되어 요청이 실패하였습니다. 

### 해결
정적 라우터를 동적 라우터보다 먼저 선언합니다.

### 참고자료
https://github.com/nestjs/nest/issues/13104


## 스크린샷
