### PR TITLE
[Feat] 참여자 목록 조회 API 구현

### DIFF
--- a/apps/api/src/dashboard/dashboard.controller.ts
+++ b/apps/api/src/dashboard/dashboard.controller.ts
@@ -17,7 +17,9 @@ export class DashboardController {
   }
 
   @Get('created/:ticleId/applicants')
-  getParticipants(@Param('ticleId') ticleId: number) {}
+  async getApplicants(@Param('ticleId') ticleId: number) {
+    return await this.dashboardService.getApplicants(ticleId);
+  }
 
   @Post('created/:ticleId/start')
   startTicle(@Param('ticleId') ticleId: number) {}

--- a/apps/api/src/dashboard/dashboard.service.ts
+++ b/apps/api/src/dashboard/dashboard.service.ts
@@ -18,6 +18,7 @@ export class DashboardService {
     try {
       return await this.ticleRepository.find({
         where: { speaker: { id: speakerId } },
+        select: ['title', 'startTime', 'endTime', 'ticleStatus'],
       });
     } catch (error) {
       throw new BadRequestException('개설한 티클 조회에 실패했습니다.');
@@ -26,12 +27,18 @@ export class DashboardService {
 
   async getAppliedTicleList(userId: number) {
     try {
-      const applicants = await this.applicantRepository.find({
+      return await this.applicantRepository.find({
         where: { user: { id: userId } },
         relations: ['ticle'],
+        select: {
+          ticle: {
+            title: true,
+            startTime: true,
+            endTime: true,
+            ticleStatus: true,
+          },
+        },
       });
-
-      return applicants.map((applicant) => applicant.ticle);
     } catch (error) {
       throw new BadRequestException('신청한 티클 조회에 실패했습니다.');
     }
@@ -39,15 +46,16 @@ export class DashboardService {
 
   async getApplicants(ticleId: number) {
     try {
-      const applicants = await this.applicantRepository.find({
+      return await this.applicantRepository.find({
         where: { ticle: { id: ticleId } },
         relations: ['user'],
+        select: {
+          user: {
+            nickname: true,
+            profileImageUrl: true,
+          },
+        },
       });
-
-      return applicants.map((applicant) => ({
-        nickname: applicant.user.nickname,
-        profileImageUrl: applicant.user.profileImageUrl,
-      }));
     } catch (error) {
       throw new BadRequestException('참여자 목록 조회에 실패했습니다.');
     }

--- a/apps/api/src/dashboard/dashboard.service.ts
+++ b/apps/api/src/dashboard/dashboard.service.ts
@@ -44,7 +44,10 @@ export class DashboardService {
         relations: ['user'],
       });
 
-      return applicants.map((applicant) => applicant.user);
+      return applicants.map((applicant) => ({
+        nickname: applicant.user.nickname,
+        profileImageUrl: applicant.user.profileImageUrl,
+      }));
     } catch (error) {
       throw new BadRequestException('참여자 목록 조회에 실패했습니다.');
     }

--- a/apps/api/src/dashboard/dashboard.service.ts
+++ b/apps/api/src/dashboard/dashboard.service.ts
@@ -36,4 +36,17 @@ export class DashboardService {
       throw new BadRequestException('신청한 티클 조회에 실패했습니다.');
     }
   }
+
+  async getApplicants(ticleId: number) {
+    try {
+      const applicants = await this.applicantRepository.find({
+        where: { ticle: { id: ticleId } },
+        relations: ['user'],
+      });
+
+      return applicants.map((applicant) => applicant.user);
+    } catch (error) {
+      throw new BadRequestException('참여자 목록 조회에 실패했습니다.');
+    }
+  }
 }


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat] {제목~~} -->
<!-- Reviewer, Assignees, Label 붙이기 -->

## 관련 이슈 번호

<!-- 이슈를 닫지 않는다면 이유 작성하기 -->

- close #85

## 작업 내용
- 개설한 speaker 입장에서 참여자 목록에 대한 조회가 가능하도록 구현.
- User 정보 중에서 nickname과 profileImageUrl만 담음.

## PR 포인트
- applicant 테이블에서 해당하는 ticleId로 해당하는 user들을 찾고, 피그마와 동일하게 user 정보들 중에서 user의 닉네임과 프로필이미지의 url만 리턴하도록 구현하였습니다.

## 고민과 학습내용
- 피그마 상에는 프로필이미지와 이름만 뜨도록 구현이 되어서 이렇게만 했습니다. 신청할 때 중복 검사도 할 것 같아서 우선은 따로 검증하는 로직은 추가하지 않았고, db에 저장되는 순서대로 꺼내올 것 같아서 applicant의 createdAt도 사용하지 않았습니다. 참여자 정보들을 꺼내오는 순서들이 상관이 없다면 이대로 진행하면 될 것 같습니다!
```ts
return applicants.map((applicant) => ({
        nickname: applicant.user.nickname,
        profileImageUrl: applicant.user.profileImageUrl,
      }));
``` 

## 스크린샷
