### PR TITLE
[Feat] ticle 상세정보에 프로필 이미지 Url 추가

### DIFF
--- a/apps/api/src/ticle/dto/ticleDetailDto.ts
+++ b/apps/api/src/ticle/dto/ticleDetailDto.ts
@@ -50,4 +50,10 @@ export class TickleDetailResponseDto {
     type: [String],
   })
   tags: string[];
+
+  @ApiProperty({
+    example: 'img url',
+    description: '발표자 프로필 이미지 Url',
+  })
+  speakerImgUrl: string;
 }

--- a/apps/api/src/ticle/ticle.service.ts
+++ b/apps/api/src/ticle/ticle.service.ts
@@ -129,21 +129,23 @@ export class TicleService {
   }
 
   async getTicleByTicleId(ticleId: number): Promise<TickleDetailResponseDto> {
-    const ticle = await this.ticleRepository.findOne({
-      where: { id: ticleId },
-      relations: {
-        tags: true,
-      },
-    });
+    const ticle = await this.ticleRepository
+      .createQueryBuilder('ticle')
+      .leftJoinAndSelect('ticle.tags', 'tags')
+      .leftJoinAndSelect('ticle.speaker', 'speaker')
+      .select(['ticle', 'tags', 'speaker.id', 'speaker.profileImageUrl'])
+      .where('ticle.id = :id', { id: ticleId })
+      .getOne();
 
     if (!ticle) {
       throw new NotFoundException('티클을 찾을 수 없습니다.');
     }
-    const { tags, ...ticleData } = ticle;
+    const { tags, speaker, ...ticleData } = ticle;
 
     return {
       ...ticleData,
       tags: tags.map((tag) => tag.name),
+      speakerImgUrl: speaker.profileImageUrl,
     };
   }
 


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat] {제목~~} -->
<!-- Reviewer, Assignees, Label 붙이기 -->

## 관련 이슈 번호

<!-- 이슈를 닫지 않는다면 이유 작성하기 -->
Ticle 상세 정보 조회를 수정했습니다. 

## 작업 내용
- Ticle 상세정보에 speaker의 프로필 이미지 추가 

## PR 포인트

## 고민과 학습내용

speaker라는 사용자의 프로필 이미지를 사용해야하므로, 쿼리를 수정했습니다. 
또한, Speaker의 모든 정보를 반환하지 않기 위해 선택적으로 imageUrl 만 반환하도록 했습니다. 


## 스크린샷
