### PR TITLE
[Feat] 로그인 정보 없을떄 에러추가, 토큰인증실패시 에러추가

### DIFF
--- a/apps/api/src/auth/jwt/jwt-auth.guard.ts
+++ b/apps/api/src/auth/jwt/jwt-auth.guard.ts
@@ -1,17 +1,25 @@
-import { ExecutionContext, Injectable } from '@nestjs/common';
+import { ExecutionContext, Injectable, UnauthorizedException } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 
 @Injectable()
 export class JwtAuthGuard extends AuthGuard('jwt') {
   getRequest(context: ExecutionContext) {
     const req = context.switchToHttp().getRequest();
-
     const cookies = req.cookies;
-
     const token = cookies['accessToken'];
 
-    if (token) req.headers.authorization = `Bearer ${token}`;
+    if (!token) {
+      throw new UnauthorizedException('로그인이 필요합니다.');
+    }
+    req.headers.authorization = `Bearer ${token}`;
 
     return req;
+  }
+
+  handleRequest(err: any, user: any) {
+    if (err || !user) {
+      throw new UnauthorizedException('잘못된 인증 정보입니다.');
+    }
+    return user;
   }
 }


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat] {제목~~} -->
<!-- Reviewer, Assignees, Label 붙이기 -->

## 관련 이슈 번호

<!-- 이슈를 닫지 않는다면 이유 작성하기 -->

- close #246  

## 작업 내용
- 로그인정보 없을떄 (쿠키에 accessToken 없을때) 에러생성
- jwt토큰 해독실패 시 에러 메시지 수정
## PR 포인트

## 고민과 학습내용

## 스크린샷
- 쿠키에 accessToken이 없을 때
<img width="481" alt="스크린샷 2024-11-23 오후 9 23 37" src="https://github.com/user-attachments/assets/8786e029-a6e6-48b1-849b-7a7d636df306">
- jwt토큰 해독실패 시
<img width="413" alt="스크린샷 2024-11-23 오후 9 26 51" src="https://github.com/user-attachments/assets/93cad8f2-d613-4e08-9b44-fe448faad7be">

