### PR TITLE
[Fix] applicant Count 수정

### DIFF
--- a/apps/api/src/ticle/ticle.service.ts
+++ b/apps/api/src/ticle/ticle.service.ts
@@ -166,14 +166,14 @@ export class TicleService {
         'ticle.speakerName',
         'ticle.createdAt',
       ])
+      .addSelect('GROUP_CONCAT(DISTINCT tags.name)', 'tagNames')
+      .addSelect('COUNT(DISTINCT applicant.id)', 'applicantCount')
+      .leftJoin('ticle.tags', 'tags')
+      .leftJoin('ticle.applicants', 'applicant')
       .where('ticle.ticleStatus = :status', {
         status: isOpen ? TicleStatus.OPEN : TicleStatus.CLOSED,
       })
-      .leftJoin('ticle.tags', 'tags')
-      .addSelect('GROUP_CONCAT(tags.name)', 'tagNames')
-      .groupBy('ticle.id')
-      .addSelect('COUNT(DISTINCT applicant.id)', 'applicantCount')
-      .leftJoin('ticle.applicants', 'applicant');
+      .groupBy('ticle.id');
 
     switch (sort) {
       case SortType.OLDEST:


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat] {제목~~} -->
<!-- Reviewer, Assignees, Label 붙이기 -->

## 관련 이슈 번호

<!-- 이슈를 닫지 않는다면 이유 작성하기 -->

- close #249 

## 작업 내용
- applicantCount가 제대로 표시되지 않는 것을 수정했습니다. 

## PR 포인트

## 고민과 학습내용

1. applicant의 수를 가져오기 위해 group by 와 join을 사용하였습니다. 
이 과정에서 tag로 인해 조회하는 entity개수가 늘어는 버그가 있어서, Tag를 문자열로 받고 split을 이용하였습니다. 

2. 위 문제들을 해결하기 위해 `getRawMany` 를 이용하게 되었습니다. 
`getRawMany`를 이용하면 Entity가 아니라 테이블의 칼럼명에 직접 접근해야 했습니다. 예를들어 `createdAt` 이 아니라 `created_at`으로 접근하여 값을 가져왔습니다. 

3. limit & offset
skip과 take는 TypeORM의 엔티티 처리 과정에서 동작합니다
`getRawMany`를 사용할 때는 이 엔티티 처리 과정을 건너뛰기 때문에 페이지네이션이 적용되지 않습니다
따라서 Limit offset을 사용하게 되었습니다. 
+) limit offset의 성능상 이슈가 있어서 SubQuery로 개선하는 방법이나 cursor기반 쿼리로 변경할 필요성이 있습니다.



## 스크린샷
