### PR TITLE
[Feat] new-producer, get-producers 이벤트 응답객체, join-room이벤트 파라미터에 nickname 추가

### DIFF
--- a/apps/media/src/mediasoup/mediasoup.service.ts
+++ b/apps/media/src/mediasoup/mediasoup.service.ts
@@ -146,7 +146,7 @@ export class MediasoupService implements OnModuleInit {
     };
   }
 
-  async getProducers(roomId: string, socketId: string) {
+  getProducers(roomId: string, socketId: string) {
     const room = this.roomService.getRoom(roomId);
 
     const peers = [...room.peers.values()];
@@ -157,10 +157,11 @@ export class MediasoupService implements OnModuleInit {
       [...peer.producers.values()].map(({ id, kind, appData, paused }) => {
         return {
           producerId: id,
-          kind,
-          paused,
           peerId: peer.socketId,
+          nickname: peer.nickname,
+          kind,
           appData: appData,
+          paused,
         };
       })
     );

--- a/apps/media/src/mediasoup/mediasoup.service.ts
+++ b/apps/media/src/mediasoup/mediasoup.service.ts
@@ -111,7 +111,7 @@ export class MediasoupService implements OnModuleInit {
     const producer = await transport.produce({ kind, rtpParameters, appData });
 
     peer.addProducer(producer);
-    return { nickname: peer.nickname, ...producer };
+    return { nickname: peer.nickname, producerId: producer.id, paused: producer.paused };
   }
 
   async consume(

--- a/apps/media/src/mediasoup/mediasoup.service.ts
+++ b/apps/media/src/mediasoup/mediasoup.service.ts
@@ -111,7 +111,7 @@ export class MediasoupService implements OnModuleInit {
     const producer = await transport.produce({ kind, rtpParameters, appData });
 
     peer.addProducer(producer);
-    return producer;
+    return { nickname: peer.nickname, ...producer };
   }
 
   async consume(

--- a/apps/media/src/mediasoup/mediasoup.service.ts
+++ b/apps/media/src/mediasoup/mediasoup.service.ts
@@ -60,12 +60,12 @@ export class MediasoupService implements OnModuleInit {
     return this.roomService.createRoom(roomId, router);
   }
 
-  joinRoom(roomId: string, socketId: string) {
+  joinRoom(roomId: string, socketId: string, nickname: string) {
     const room = this.roomService.getRoom(roomId);
     if (room.hasPeer(socketId)) {
       throw new WsException(`Peer ${socketId} already exists`);
     }
-    room.addPeer(socketId);
+    room.addPeer(socketId, nickname);
 
     return room.getRouter().rtpCapabilities;
   }

--- a/apps/media/src/room/peer.ts
+++ b/apps/media/src/room/peer.ts
@@ -3,13 +3,14 @@ import { types } from 'mediasoup';
 
 export class Peer {
   socketId: string;
-
+  nickname: string;
   transports: Map<string, types.Transport>;
   producers: Map<string, types.Producer>;
   consumers: Map<string, types.Consumer>;
 
-  constructor(socketId: string) {
+  constructor(socketId: string, nickname: string) {
     this.socketId = socketId;
+    this.nickname = nickname;
     this.transports = new Map();
     this.producers = new Map();
     this.consumers = new Map();

--- a/apps/media/src/room/room.ts
+++ b/apps/media/src/room/room.ts
@@ -18,8 +18,8 @@ export class Room {
     return this.router;
   }
 
-  addPeer(socketId: string) {
-    const peer = new Peer(socketId);
+  addPeer(socketId: string, nickname: string) {
+    const peer = new Peer(socketId, nickname);
     this.peers.set(socketId, peer);
     return peer;
   }

--- a/apps/media/src/signaling/signaling.gateway.ts
+++ b/apps/media/src/signaling/signaling.gateway.ts
@@ -22,10 +22,11 @@ export class SignalingGateway implements OnGatewayDisconnect {
   }
 
   @SubscribeMessage(SOCKET_EVENTS.joinRoom)
-  joinRoom(@ConnectedSocket() client: Socket, @MessageBody('roomId') roomId: string) {
+  joinRoom(@ConnectedSocket() client: Socket, @MessageBody() joinRoomDto: server.JoinRoomDto) {
+    const { roomId, nickname } = joinRoomDto;
     client.join(roomId);
-    const rtpCapabilities = this.mediasoupService.joinRoom(roomId, client.id);
-    client.to(roomId).emit('new-peer', { peerId: client.id });
+    const rtpCapabilities = this.mediasoupService.joinRoom(roomId, client.id, nickname);
+    client.to(roomId).emit(SOCKET_EVENTS.newPeer, { peerId: client.id });
     return { rtpCapabilities };
   }
 

--- a/apps/media/src/signaling/signaling.gateway.ts
+++ b/apps/media/src/signaling/signaling.gateway.ts
@@ -73,6 +73,7 @@ export class SignalingGateway implements OnGatewayDisconnect {
     const createProducerRes = {
       producerId: producer.id,
       peerId: client.id,
+      nickname: producer.nickname,
       kind,
       appData,
       paused: producer.paused,

--- a/apps/media/src/signaling/signaling.gateway.ts
+++ b/apps/media/src/signaling/signaling.gateway.ts
@@ -61,7 +61,7 @@ export class SignalingGateway implements OnGatewayDisconnect {
     @MessageBody() createProducerDto: server.CreateProducerDto
   ): Promise<client.CreateProducerRes> {
     const { transportId, kind, rtpParameters, roomId, appData } = createProducerDto;
-    const producer = await this.mediasoupService.produce(
+    const producerData = await this.mediasoupService.produce(
       client.id,
       kind,
       rtpParameters,
@@ -71,12 +71,12 @@ export class SignalingGateway implements OnGatewayDisconnect {
     );
 
     const createProducerRes = {
-      producerId: producer.id,
+      producerId: producerData.producerId,
       peerId: client.id,
-      nickname: producer.nickname,
+      nickname: producerData.nickname,
       kind,
       appData,
-      paused: producer.paused,
+      paused: producerData.paused,
     };
 
     client.to(roomId).emit(SOCKET_EVENTS.newProducer, createProducerRes);

--- a/apps/media/src/signaling/signaling.gateway.ts
+++ b/apps/media/src/signaling/signaling.gateway.ts
@@ -102,7 +102,7 @@ export class SignalingGateway implements OnGatewayDisconnect {
   }
 
   @SubscribeMessage(SOCKET_EVENTS.getProducer)
-  async getProducers(
+  getProducers(
     @ConnectedSocket() client: Socket,
     @MessageBody() getProducerDto: server.GetProducersDto
   ) {

--- a/packages/mediasoup/src/client/index.ts
+++ b/packages/mediasoup/src/client/index.ts
@@ -20,6 +20,7 @@ export interface ConsumerTransports {
 export interface CreateProducerRes {
   kind: types.MediaKind;
   peerId: string;
+  nickname: string;
   producerId: string;
   paused: boolean;
   appData?: { mediaTypes: MediaTypes };

--- a/packages/mediasoup/src/server/index.ts
+++ b/packages/mediasoup/src/server/index.ts
@@ -2,6 +2,11 @@ import { types } from 'mediasoup';
 
 import { MediaTypes, StreamStatus } from '../types';
 
+export interface JoinRoomDto {
+  roomId: string;
+  nickname: string;
+}
+
 export interface ConnectTransportDto {
   transportId: string;
   dtlsParameters: types.DtlsParameters;

--- a/packages/types/src/ticle/ticleDetail.ts
+++ b/packages/types/src/ticle/ticleDetail.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+
 import { TicleStatus } from './ticleStatus';
 
 export const TicleDetailResponseSchema = z.object({


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat] {제목~~} -->
<!-- Reviewer, Assignees, Label 붙이기 -->

## 관련 이슈 번호

<!-- 이슈를 닫지 않는다면 이유 작성하기 -->

- close #259 

## 작업 내용
-  join-room 이벤트시 nickname필요하게 변경, `JoinRoomDto`생성
```typescript
export interface JoinRoomDto {
  roomId: string;
  nickname: string;
}
```
- new-producer, get-producers 이벤트 시 응답객체에 nickname추가, 타입 수정
- 불필요한 async 제거 
   - `get-producers`이벤트 로직에 붙어있던 async를 제거했습니다.
   - 로직에는 단순 반복문만 있습니다.
## PR 포인트
- `join-room` 이벤트 시 nickname을 받으면 peer객체에서 관리하게 됩니다.
- 코드의 효율성
    - peer.id, peer.nicname으로 계속 접근하니 비효율적이지 않을까요...? (producer가 peer 당 3개까지 있으니, peer.으로 여러번 접근하게 됩니다)
    - ~큰 차이는 없을 것 같지만 만약 고치면 밑에코드처럼 바꿀 수 있을 것 같습니다.~
    - gpt에게 물어보니 별차이없다고 현재코드를 선호한다네요. 성능은 차이 안나는 수준이라고 가독성을 중시하라네요
```typescript
//현재코드
const result = filtered.flatMap((peer) =>
      [...peer.producers.values()].map(({ id, kind, appData, paused }) => {
        return {
          producerId: id,
          peerId: peer.socketId,
          nickname: peer.nickname,
          kind,
          appData: appData,
          paused,
        };
      })
    );


//수정해보면 어떨까...?
const result = filtered.flatMap((peer) => {
      const peerId = peer.socketId;
      const nickname = peer.nickname;
      [...peer.producers.values()].map(({ id, kind, appData, paused }) => {
        return {
          producerId: id,
          peerId: peerId,
          nickname: nickname,
          kind,
          appData: appData,
          paused,
        };
      });
    });
```

## 고민과 학습내용
- 클라이언트에서는 사진과 같이 응답을 받게 됩니다!
## 스크린샷
![스크린샷 2024-11-25 오후 3 25 04](https://github.com/user-attachments/assets/06f01715-0a9e-4d50-bfa6-ab8c160a29cb)
