### PR TITLE
[Feat] media 서버 이벤트 정리 및 Consumer 상태 관리 이벤트 추가

### DIFF
--- a/apps/media/src/mediasoup/mediasoup.service.ts
+++ b/apps/media/src/mediasoup/mediasoup.service.ts
@@ -38,6 +38,7 @@ export class MediasoupService implements OnModuleInit {
     });
 
     this.workers.push(worker);
+
     return worker;
   }
 
@@ -192,8 +193,20 @@ export class MediasoupService implements OnModuleInit {
     });
 
     consumer.on('producerclose', () => {
-      peer.consumers.delete(consumer.id);
       consumer.close();
+      peer.consumers.delete(consumer.id);
+    });
+
+    consumer.on('producerpause', () => {
+      consumer.pause();
+    });
+
+    consumer.on('producerresume', () => {
+      if (consumer.kind !== 'audio') {
+        return;
+      }
+
+      consumer.resume();
     });
 
     peer.addConsumer(consumer);
@@ -214,12 +227,11 @@ export class MediasoupService implements OnModuleInit {
     );
   }
 
-  closeProducer(roomId: string, producerId: string, socketId: string) {
+  async closeProducer(roomId: string, producerId: string, socketId: string) {
     const room = this.roomService.getRoom(roomId);
     const peer = room.peers.get(socketId);
 
     peer.deleteProducer(producerId);
-    room.removeConsumersByProducerId(producerId);
 
     return producerId;
   }

--- a/apps/media/src/room/peer.ts
+++ b/apps/media/src/room/peer.ts
@@ -93,17 +93,6 @@ export class Peer {
     consumer.resume();
   }
 
-  removeConsumerByProducerId(producerId: string) {
-    const consumer = this.getConsumerByProducerId(producerId);
-
-    if (!consumer) {
-      return;
-    }
-
-    consumer.close();
-    this.consumers.delete(consumer.id);
-  }
-
   close() {
     this.consumers.forEach((consumer) => consumer.close());
     this.producers.forEach((producer) => producer.close());

--- a/apps/media/src/room/peer.ts
+++ b/apps/media/src/room/peer.ts
@@ -53,6 +53,57 @@ export class Peer {
     return this.consumers.get(consumerId);
   }
 
+  deleteProducer(producerId: string) {
+    const producer = this.producers.get(producerId);
+
+    if (!producer) {
+      return;
+    }
+
+    producer.close();
+
+    this.producers.delete(producerId);
+  }
+
+  getConsumerByProducerId(producerId: string) {
+    const consumer = Array.from(this.consumers.values()).find(
+      (consumer) => consumer.producerId === producerId
+    );
+
+    return consumer;
+  }
+
+  pauseConsumerByProducerId(producerId: string) {
+    const consumer = this.getConsumerByProducerId(producerId);
+
+    if (!consumer) {
+      return;
+    }
+
+    consumer.pause();
+  }
+
+  resumeConsumerByProducerId(producerId: string) {
+    const consumer = this.getConsumerByProducerId(producerId);
+
+    if (!consumer) {
+      return;
+    }
+
+    consumer.resume();
+  }
+
+  removeConsumerByProducerId(producerId: string) {
+    const consumer = this.getConsumerByProducerId(producerId);
+
+    if (!consumer) {
+      return;
+    }
+
+    consumer.close();
+    this.consumers.delete(consumer.id);
+  }
+
   close() {
     this.consumers.forEach((consumer) => consumer.close());
     this.producers.forEach((producer) => producer.close());

--- a/apps/media/src/room/room.ts
+++ b/apps/media/src/room/room.ts
@@ -51,10 +51,6 @@ export class Room {
     return false;
   }
 
-  removeConsumersByProducerId(producerId: string) {
-    this.peers.forEach((peer) => peer.removeConsumerByProducerId(producerId));
-  }
-
   close() {
     this.peers.forEach((peer) => peer.close());
     this.peers.clear();

--- a/apps/media/src/room/room.ts
+++ b/apps/media/src/room/room.ts
@@ -51,6 +51,10 @@ export class Room {
     return false;
   }
 
+  removeConsumersByProducerId(producerId: string) {
+    this.peers.forEach((peer) => peer.removeConsumerByProducerId(producerId));
+  }
+
   close() {
     this.peers.forEach((peer) => peer.close());
     this.peers.clear();

--- a/apps/media/src/signaling/signaling.gateway.ts
+++ b/apps/media/src/signaling/signaling.gateway.ts
@@ -104,7 +104,7 @@ export class SignalingGateway implements OnGatewayDisconnect {
     );
   }
 
-  @SubscribeMessage(SOCKET_EVENTS.getProducer)
+  @SubscribeMessage(SOCKET_EVENTS.getProducers)
   getProducers(
     @ConnectedSocket() client: Socket,
     @MessageBody() getProducerDto: server.GetProducersDto
@@ -125,7 +125,7 @@ export class SignalingGateway implements OnGatewayDisconnect {
     @MessageBody('roomId') roomId: string,
     @MessageBody('producerId') producerId: string
   ) {
-    this.mediasoupService.disconnectProducer(roomId, producerId, client.id);
+    this.mediasoupService.closeProducer(roomId, producerId, client.id);
 
     client.to(roomId).emit(SOCKET_EVENTS.producerClosed, { producerId });
   }
@@ -148,13 +148,21 @@ export class SignalingGateway implements OnGatewayDisconnect {
     return { producerId };
   }
 
-  @SubscribeMessage(SOCKET_EVENTS.consumerStatusChange)
-  pauseConsumer(
+  @SubscribeMessage(SOCKET_EVENTS.pauseConsumers)
+  pauseConsumers(
     @ConnectedSocket() client: Socket,
-    @MessageBody() changeConsumerState: server.ChangeConsumerStateDto
+    @MessageBody('roomId') roomId: string,
+    @MessageBody('consumerIds') consumerIds: string[]
   ) {
-    const { consumerId } = changeConsumerState;
-    this.mediasoupService.changeConsumerStatus(client.id, changeConsumerState);
-    return consumerId;
+    this.mediasoupService.pauseConsumers(client.id, roomId, consumerIds);
+  }
+
+  @SubscribeMessage(SOCKET_EVENTS.resumeConsumers)
+  resumeConsumers(
+    @ConnectedSocket() client: Socket,
+    @MessageBody('roomId') roomId: string,
+    @MessageBody('consumerIds') consumerIds: string[]
+  ) {
+    this.mediasoupService.resumeConsumers(client.id, roomId, consumerIds);
   }
 }

--- a/apps/media/src/signaling/signaling.gateway.ts
+++ b/apps/media/src/signaling/signaling.gateway.ts
@@ -88,22 +88,6 @@ export class SignalingGateway implements OnGatewayDisconnect {
     return createProducerRes;
   }
 
-  @SubscribeMessage(SOCKET_EVENTS.consume)
-  async handleConsume(
-    @ConnectedSocket() client: Socket,
-    @MessageBody() createConsumerDto: server.CreateConsumerDto
-  ): Promise<client.CreateConsumerRes> {
-    const { transportId, producerId, roomId, rtpCapabilities } = createConsumerDto;
-
-    return this.mediasoupService.consume(
-      client.id,
-      producerId,
-      roomId,
-      transportId,
-      rtpCapabilities
-    );
-  }
-
   @SubscribeMessage(SOCKET_EVENTS.getProducers)
   getProducers(
     @ConnectedSocket() client: Socket,
@@ -146,6 +130,30 @@ export class SignalingGateway implements OnGatewayDisconnect {
     }
 
     return { producerId };
+  }
+
+  @SubscribeMessage(SOCKET_EVENTS.consume)
+  async handleConsume(
+    @ConnectedSocket() client: Socket,
+    @MessageBody() createConsumerDto: server.CreateConsumerDto
+  ): Promise<client.CreateConsumerRes> {
+    const { transportId, producerId, roomId, rtpCapabilities } = createConsumerDto;
+
+    return this.mediasoupService.consume(
+      client.id,
+      producerId,
+      roomId,
+      transportId,
+      rtpCapabilities
+    );
+  }
+
+  @SubscribeMessage(SOCKET_EVENTS.createConsumers)
+  async createConsumers(
+    @ConnectedSocket() client: Socket,
+    @MessageBody() createConsumersDto: server.CreateConsumerDto[]
+  ) {
+    await this.mediasoupService.createConsumers(client.id, createConsumersDto);
   }
 
   @SubscribeMessage(SOCKET_EVENTS.pauseConsumers)

--- a/packages/mediasoup/src/events.ts
+++ b/packages/mediasoup/src/events.ts
@@ -30,6 +30,7 @@ export const SOCKET_EVENTS = {
   producerStatusChange: 'producer-status-change',
 
   consume: 'consume',
+  createConsumers: 'create-consumers',
   consumerClosed: 'consumer-closed',
   consumerPaused: 'consumer-paused',
   pauseConsumers: 'pause-consumers',

--- a/packages/mediasoup/src/events.ts
+++ b/packages/mediasoup/src/events.ts
@@ -9,26 +9,31 @@ export const SOCKET_EVENTS = {
   reconnectFailed: 'reconnect_failed',
 
   // MediaSoup 관련 이벤트
-  closeRoom: 'close-room',
-  roomClosed: 'room-closed',
-  newPeer: 'new-peer',
-  newProducer: 'new-producer',
-  peerLeft: 'peer-left',
-  consumerClosed: 'consumer-closed',
-  consumerPaused: 'consumer-paused',
-  closeProducer: 'close-producer',
-  producerStatusChange: 'producer-status-change',
-  consumerStatusChange: 'consumer-status-change',
-  producerPaused: 'producer-paused',
-  producerResumed: 'producer-resumed',
-  producerClosed: 'producer-closed',
-  createRoom: 'create-room',
   joinRoom: 'join-room',
+  closeRoom: 'close-room',
+  createRoom: 'create-room',
+  roomClosed: 'room-closed',
+
   createTransport: 'create-transport',
   connectTransport: 'connect-transport',
+
+  newPeer: 'new-peer',
+  peerLeft: 'peer-left',
+
   produce: 'produce',
-  getProducer: 'get-producer',
+  newProducer: 'new-producer',
+  getProducers: 'get-producers',
+  closeProducer: 'close-producer',
+  producerClosed: 'producer-closed',
+  producerPaused: 'producer-paused',
+  producerResumed: 'producer-resumed',
+  producerStatusChange: 'producer-status-change',
+
   consume: 'consume',
+  consumerClosed: 'consumer-closed',
+  consumerPaused: 'consumer-paused',
+  pauseConsumers: 'pause-consumers',
+  resumeConsumers: 'resume-consumers',
 } as const;
 
 export const TRANSPORT_EVENTS = {


### PR DESCRIPTION
## 관련 이슈 번호

- 기존 기능에 consumer에 대한 상태 변경 기능을 추가하였습니다.

## 작업 내용

- Consumer 상태를 여러번 받아오지 않도록 로직 수정
- producer pause시 관련 consumer pause되도록 변경



