### PR TITLE
[Feat] 티클 상세 조회시 isOwner, alreadyApplied에 따른 신청 버튼 분기처리

### DIFF
--- a/apps/api/src/ticle/ticle.service.ts
+++ b/apps/api/src/ticle/ticle.service.ts
@@ -134,7 +134,8 @@ export class TicleService {
       .leftJoinAndSelect('ticle.tags', 'tags')
       .leftJoinAndSelect('ticle.speaker', 'speaker')
       .leftJoinAndSelect('ticle.applicants', 'applicants')
-      .select(['ticle', 'tags', 'speaker.id', 'speaker.profileImageUrl', 'applicants'])
+      .leftJoinAndSelect('applicants.user', 'user')
+      .select(['ticle', 'tags', 'speaker.id', 'speaker.profileImageUrl', 'applicants', 'user.id'])
       .where('ticle.id = :id', { id: ticleId })
       .getOne();
 
@@ -143,7 +144,7 @@ export class TicleService {
     }
     const { tags, speaker, ...ticleData } = ticle;
 
-    const alreadyApplied = ticle.applicants.some((applicnat) => applicnat.id === userId);
+    const alreadyApplied = ticle.applicants.some((applicant) => applicant.user.id === userId);
 
     return {
       ...ticleData,

--- a/apps/web/src/components/ticle/detail/index.tsx
+++ b/apps/web/src/components/ticle/detail/index.tsx
@@ -78,7 +78,11 @@ function Detail() {
           </div>
         </div>
       </div>
-      <Button onClick={handleApplyButtonClick}>티클 신청하기</Button>
+      {!data.isOwner && (
+        <Button onClick={handleApplyButtonClick} disabled={data.alreadyApplied}>
+          {data.alreadyApplied ? '신청 완료' : '티클 신청하기'}
+        </Button>
+      )}
     </div>
   );
 }

--- a/apps/web/src/hooks/api/ticle.ts
+++ b/apps/web/src/hooks/api/ticle.ts
@@ -58,6 +58,7 @@ export const useApplyTicle = () => {
       navigate({ to: `/dashboard/apply` });
       queryClient.invalidateQueries({ queryKey: ['ticleList'] });
       queryClient.invalidateQueries({ queryKey: ['dashboardTicleList'] });
+      queryClient.invalidateQueries({ queryKey: ['ticle', ticleId] });
       queryClient.invalidateQueries({ queryKey: ['applicantsTicle', ticleId] });
     },
   });

--- a/packages/types/src/ticle/ticleDetail.ts
+++ b/packages/types/src/ticle/ticleDetail.ts
@@ -16,6 +16,8 @@ export const TicleDetailResponseSchema = z.object({
   createdAt: z.string().datetime(),
   tags: z.array(z.string()),
   speakerImgUrl: z.string().url(),
+  isOwner: z.boolean(),
+  alreadyApplied: z.boolean(),
 });
 
 export type TicleDetailResponse = z.infer<typeof TicleDetailResponseSchema>;


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat] {제목~~} -->
<!-- Reviewer, Assignees, Label 붙이기 -->

## 관련 이슈 번호

<!-- 이슈를 닫지 않는다면 이유 작성하기 -->

브랜치 이름에 이슈를 잘못달았네요!ㅠㅠ
- close #315

## 작업 내용
- isOwner (내 티클)일 때 신청 버튼 보이지 않게함
- alreadyApplied (이미 신청한 티클)일 때 버튼을 disabled함
- alreadyApplied 관련 서버 코드 변경

## PR 포인트

서버에서 alreadyApplied 여부를 확인할 때,
현재 로그인한 유저의 userId를 비교해야하는데
userId가 아니라 applicantId를 비교하고있어서 비교가 제대로 되지 않고있었습니다.
따라서 user 테이블을 조인해서 user id를 확인할 수 있도록 했습니다.
[관련 commit](https://github.com/boostcampwm-2024/web21-TICLE/pull/312/commits/4bda6d28a7f7a3e68df256760557b6014d3248b6)
확인해보시면 좋을거같습니다.

오늘 오전 회의 내용에 따라서 구현 방식이 달라져야하는 부분입니다.

## 고민과 학습내용

## 스크린샷
### 내가 개설한 티클일 경우 신청하기 버튼이 보이지 않음
<img width="1680" alt="image" src="https://github.com/user-attachments/assets/095eef16-7bc4-4ca8-983c-fb10eb585179">

### 이미 신청한 티클일 경우 버튼이 disabled된 채로 '신청 완료'라고 표시함
<img width="1680" alt="image" src="https://github.com/user-attachments/assets/89d86f73-7e69-4d92-b5df-75e977541982">
