### PR TITLE
[Feat] Select 공통 컴포넌트 개선

### DIFF
--- a/apps/web/src/components/common/Select/index.tsx
+++ b/apps/web/src/components/common/Select/index.tsx
@@ -48,6 +48,7 @@ function Select({ options, placeholder, selectedOption, onChange }: Select) {
   });
 
   const selectRef = useRef<HTMLDivElement>(null);
+  const optionRef = useRef<HTMLUListElement>(null);
 
   const updatePosition = () => {
     if (!selectRef.current) return;
@@ -98,7 +99,7 @@ function Select({ options, placeholder, selectedOption, onChange }: Select) {
     handleOptionChange(option);
   };
 
-  useOutsideClick(selectRef, handleSelectClose);
+  useOutsideClick(optionRef, handleSelectClose);
 
   return (
     <div ref={selectRef} className="relative w-32">
@@ -113,6 +114,7 @@ function Select({ options, placeholder, selectedOption, onChange }: Select) {
       {isOpen && (
         <Portal portalId="select">
           <ul
+            ref={optionRef}
             role="listbox"
             className="absolute right-0 mt-2 flex w-full flex-col items-center gap-1.5 rounded-base border border-main bg-white p-2 shadow-normal"
             style={{


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat] {제목~~} -->
<!-- Reviewer, Assignees, Label 붙이기 -->

## 관련 이슈 번호

<!-- 이슈를 닫지 않는다면 이유 작성하기 -->

- close #305

## 작업 내용
- Select 컴포넌트에서 드롭다운(옵션 목록)영역이 항상 위로 올라오도록 수정

## PR 포인트

## 고민과 학습내용

옵션 목록 영역을 단순히 조건부 렌더링 처리만 하는 것이 아니라,
Portal을 이용해서 항상 상위에 뜨도록 하고
옵션 목록이 표시되어야 할 위치를 getBoundingClientRect()를 통해 위치값을 계산하여 표시합니다.
깜빡임 문제를 해결하기 위해 useLayoutEffect를 사용했습니다. 따라서 위치가 모두 계산이 완료된 후에 렌더링이 되게합니다.
```tsx
const updatePosition = () => {
    if (!selectRef.current) return;

    const selectRect = selectRef.current.getBoundingClientRect();
    const scrollTop = window.scrollY || document.documentElement.scrollTop;
    const scrollLeft = window.scrollX || document.documentElement.scrollLeft;

    setPosition({
      top: selectRect.bottom + scrollTop,
      left: selectRect.left + scrollLeft,
      width: selectRect.width,
    });
  };

  useLayoutEffect(() => {
    if (!isOpen) return;

    updatePosition();

    window.addEventListener('scroll', updatePosition);
    window.addEventListener('resize', updatePosition);

    return () => {
      window.removeEventListener('scroll', updatePosition);
      window.removeEventListener('resize', updatePosition);
    };
  }, [isOpen]);
```

## 스크린샷
### AS-IS 
드롭다운 영역보다 상위의 쌓임맥락이 위로 올라와있을 경우 클릭이 안됨
아래 경우는 저 점선 부분이 :before 가상 요소로 처리되어있기 때문에 위로 올라오게 됩니다.

https://github.com/user-attachments/assets/a04e6e56-0835-406a-ae8d-0c5a3018e245

### TO-BE
드롭다운 영역이 항상 위로 올라오도록 수정

https://github.com/user-attachments/assets/c9242be6-8edc-4387-a11f-5a5d6522c1c3



