### PR TITLE
[Feat] Ticle Status 세분화

### DIFF
--- a/apps/api/src/dashboard/dashboard.controller.ts
+++ b/apps/api/src/dashboard/dashboard.controller.ts
@@ -32,7 +32,11 @@ export class DashboardController {
   }
 
   @Post('start')
-  startTicle(@Param('ticleId') ticleId: number) {}
+  @UseGuards(JwtAuthGuard)
+  async startTicle(@GetUserId() userId: number, @Param('ticleId') ticleId: number) {
+    await this.dashboardService.startTicle(userId, ticleId);
+    return 'success ticle start';
+  }
 
   @Post('join')
   joinTicle(@Param('ticleId') ticleId: number) {}

--- a/apps/api/src/dashboard/dashboard.controller.ts
+++ b/apps/api/src/dashboard/dashboard.controller.ts
@@ -31,14 +31,14 @@ export class DashboardController {
     return await this.dashboardService.getApplicants(ticleId);
   }
 
-  @Post('start')
+  @Post(':ticleId/start')
   @UseGuards(JwtAuthGuard)
   async startTicle(@GetUserId() userId: number, @Param('ticleId') ticleId: number) {
     await this.dashboardService.startTicle(userId, ticleId);
     return 'success ticle start';
   }
 
-  @Post('end')
+  @Post(':ticleId/end')
   @UseGuards(JwtAuthGuard)
   async endTicle(@GetUserId() userId: number, @Param('ticleId') ticleId: number) {
     await this.dashboardService.endTicle(userId, ticleId);

--- a/apps/api/src/dashboard/dashboard.controller.ts
+++ b/apps/api/src/dashboard/dashboard.controller.ts
@@ -38,6 +38,13 @@ export class DashboardController {
     return 'success ticle start';
   }
 
+  @Post('end')
+  @UseGuards(JwtAuthGuard)
+  async endTicle(@GetUserId() userId: number, @Param('ticleId') ticleId: number) {
+    await this.dashboardService.endTicle(userId, ticleId);
+    return 'success ticle end';
+  }
+
   @Post('join')
   joinTicle(@Param('ticleId') ticleId: number) {}
 }

--- a/apps/api/src/dashboard/dashboard.service.ts
+++ b/apps/api/src/dashboard/dashboard.service.ts
@@ -31,7 +31,13 @@ export class DashboardService {
       .take(pageSize);
 
     if (status) {
-      queryBuilder.andWhere('ticle.ticleStatus = :status', { status });
+      if (status === TicleStatus.OPEN) {
+        queryBuilder.andWhere('ticle.ticleStatus IN (:...statuses)', {
+          statuses: [TicleStatus.OPEN, TicleStatus.IN_PROGRESS],
+        });
+      } else {
+        queryBuilder.andWhere('ticle.ticleStatus = :status', { status });
+      }
     }
 
     const [ticles, totalItems] = await queryBuilder.getManyAndCount();
@@ -70,7 +76,13 @@ export class DashboardService {
       .take(pageSize);
 
     if (status) {
-      queryBuilder.andWhere('ticle.ticleStatus = :status', { status });
+      if (status === TicleStatus.OPEN) {
+        queryBuilder.andWhere('ticle.ticleStatus IN (:...statuses)', {
+          statuses: [TicleStatus.OPEN, TicleStatus.IN_PROGRESS],
+        });
+      } else {
+        queryBuilder.andWhere('ticle.ticleStatus = :status', { status });
+      }
     }
 
     const [applicants, totalItems] = await queryBuilder.getManyAndCount();

--- a/apps/api/src/dashboard/dashboard.service.ts
+++ b/apps/api/src/dashboard/dashboard.service.ts
@@ -1,7 +1,7 @@
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
-import { TicleStatus } from '@repo/types';
+import { ErrorMessage, TicleStatus } from '@repo/types';
 
 import { Applicant } from '@/entity/applicant.entity';
 import { Ticle } from '@/entity/ticle.entity';
@@ -113,5 +113,25 @@ export class DashboardService {
         },
       },
     });
+  }
+
+  async startTicle(userId: number, ticleId: number) {
+    const ticle = await this.ticleRepository.findOne({
+      where: { id: ticleId },
+    });
+
+    if (!ticle) {
+      throw new NotFoundException(ErrorMessage.TICLE_NOT_FOUND);
+    }
+    if (ticle.speaker.id !== userId) {
+      throw new BadRequestException(ErrorMessage.CANNOT_START_TICLE);
+    }
+    if (ticle.ticleStatus !== TicleStatus.OPEN) {
+      throw new BadRequestException(ErrorMessage.CANNOT_START_TICLE);
+    }
+
+    ticle.ticleStatus = TicleStatus.IN_PROGRESS;
+    await this.ticleRepository.save(ticle);
+    return;
   }
 }

--- a/apps/api/src/dashboard/dashboard.service.ts
+++ b/apps/api/src/dashboard/dashboard.service.ts
@@ -118,6 +118,7 @@ export class DashboardService {
   async startTicle(userId: number, ticleId: number) {
     const ticle = await this.ticleRepository.findOne({
       where: { id: ticleId },
+      relations: ['speaker'],
     });
 
     if (!ticle) {
@@ -138,16 +139,17 @@ export class DashboardService {
   async endTicle(userId: number, ticleId: number) {
     const ticle = await this.ticleRepository.findOne({
       where: { id: ticleId },
+      relations: ['speaker'],
     });
 
     if (!ticle) {
       throw new NotFoundException(ErrorMessage.TICLE_NOT_FOUND);
     }
     if (ticle.speaker.id !== userId) {
-      throw new BadRequestException(ErrorMessage.CANNOT_START_TICLE);
+      throw new BadRequestException(ErrorMessage.CANNOT_END_TICLE);
     }
-    if (ticle.ticleStatus !== TicleStatus.OPEN) {
-      throw new BadRequestException(ErrorMessage.CANNOT_START_TICLE);
+    if (ticle.ticleStatus !== TicleStatus.IN_PROGRESS) {
+      throw new BadRequestException(ErrorMessage.CANNOT_END_TICLE);
     }
 
     ticle.ticleStatus = TicleStatus.CLOSED;

--- a/apps/api/src/dashboard/dashboard.service.ts
+++ b/apps/api/src/dashboard/dashboard.service.ts
@@ -134,4 +134,24 @@ export class DashboardService {
     await this.ticleRepository.save(ticle);
     return;
   }
+
+  async endTicle(userId: number, ticleId: number) {
+    const ticle = await this.ticleRepository.findOne({
+      where: { id: ticleId },
+    });
+
+    if (!ticle) {
+      throw new NotFoundException(ErrorMessage.TICLE_NOT_FOUND);
+    }
+    if (ticle.speaker.id !== userId) {
+      throw new BadRequestException(ErrorMessage.CANNOT_START_TICLE);
+    }
+    if (ticle.ticleStatus !== TicleStatus.OPEN) {
+      throw new BadRequestException(ErrorMessage.CANNOT_START_TICLE);
+    }
+
+    ticle.ticleStatus = TicleStatus.CLOSED;
+    await this.ticleRepository.save(ticle);
+    return;
+  }
 }

--- a/apps/api/src/ticle/ticle.service.ts
+++ b/apps/api/src/ticle/ticle.service.ts
@@ -135,7 +135,15 @@ export class TicleService {
       .leftJoinAndSelect('ticle.speaker', 'speaker')
       .leftJoinAndSelect('ticle.applicants', 'applicants')
       .leftJoinAndSelect('applicants.user', 'user')
-      .select(['ticle', 'tags', 'speaker.id', 'speaker.profileImageUrl', 'applicants', 'user.id'])
+      .select([
+        'ticle',
+        'tags',
+        'speaker.id',
+        'speaker.profileImageUrl',
+        'applicants',
+        'user.id',
+        'ticle.ticleStatus',
+      ])
       .where('ticle.id = :id', { id: ticleId })
       .getOne();
 
@@ -176,8 +184,8 @@ export class TicleService {
       .leftJoin('ticle.tags', 'tags')
       .leftJoin('ticle.applicants', 'applicant')
       .leftJoin('ticle.speaker', 'speaker')
-      .where('ticle.ticleStatus = :status', {
-        status: isOpen ? TicleStatus.OPEN : TicleStatus.CLOSED,
+      .where('ticle.ticleStatus IN (:...statuses)', {
+        statuses: isOpen ? [TicleStatus.OPEN, TicleStatus.IN_PROGRESS] : [TicleStatus.CLOSED],
       })
       .groupBy('ticle.id');
 

--- a/apps/api/src/ticle/ticle.service.ts
+++ b/apps/api/src/ticle/ticle.service.ts
@@ -27,7 +27,7 @@ export class TicleService {
   ) {}
 
   async createTicle(createTicleDto: CreateTicleDto, userId: number): Promise<Ticle> {
-    const user = await this.userRepository.findOne({ where: { id: userId } });
+    const user = await this.getUserById(userId);
 
     const { existingTags, tagsToCreate } = await this.findExistingTags(createTicleDto.tags);
     const newTags = await this.createNewTags(tagsToCreate);

--- a/packages/types/src/dashboard/getDashboardList.ts
+++ b/packages/types/src/dashboard/getDashboardList.ts
@@ -14,7 +14,10 @@ export const GetDashboardListQuerySchema = z.object({
     .optional()
     .transform((val) => (val ? parseInt(val, 10) : 10))
     .refine((val) => !isNaN(val) && val > 0, '페이지 크기는 0보다 커야 합니다'),
-  status: z.enum([TicleStatus.CLOSED, TicleStatus.OPEN]).nullable().optional(),
+  status: z
+    .enum([TicleStatus.CLOSED, TicleStatus.OPEN, TicleStatus.IN_PROGRESS])
+    .nullable()
+    .optional(),
 });
 
 export type GetDashboardListQueryType = z.infer<typeof GetDashboardListQuerySchema>;
@@ -32,7 +35,7 @@ const BaseDashboardResponseSchema = z.object({
   title: z.string(),
   startTime: z.string().datetime(),
   endTime: z.string().datetime(),
-  ticleStatus: z.enum([TicleStatus.CLOSED, TicleStatus.OPEN]),
+  ticleStatus: z.enum([TicleStatus.CLOSED, TicleStatus.OPEN, TicleStatus.IN_PROGRESS]),
 });
 
 const AppliedTicleSchema = BaseDashboardResponseSchema.extend({

--- a/packages/types/src/errorMessages.ts
+++ b/packages/types/src/errorMessages.ts
@@ -16,6 +16,7 @@ export const ErrorMessage = {
   TICLE_ALREADY_REQUESTED: '이미 신청한 티클입니다',
   CANNOT_DELETE_OTHERS_TICLE: '다른 사람의 티클은 삭제할 수 없습니다',
   CANNOT_START_TICLE: '티클을 시작할 수 없습니다',
+  CANNOT_END_TICLE: '티클을 종료할 수 없습니다',
 
   // socket error
   PEER_NOT_FOUND_IN_ROOM: '방에 해당 peer가 존재하지 않습니다',

--- a/packages/types/src/errorMessages.ts
+++ b/packages/types/src/errorMessages.ts
@@ -15,6 +15,7 @@ export const ErrorMessage = {
   CANNOT_REQUEST_OWN_TICLE: '자신이 발표자인 티클에는 신청할 수 없습니다',
   TICLE_ALREADY_REQUESTED: '이미 신청한 티클입니다',
   CANNOT_DELETE_OTHERS_TICLE: '다른 사람의 티클은 삭제할 수 없습니다',
+  CANNOT_START_TICLE: '티클을 시작할 수 없습니다',
 
   // socket error
   PEER_NOT_FOUND_IN_ROOM: '방에 해당 peer가 존재하지 않습니다',

--- a/packages/types/src/ticle/ticleDetail.ts
+++ b/packages/types/src/ticle/ticleDetail.ts
@@ -12,7 +12,7 @@ export const TicleDetailResponseSchema = z.object({
   content: z.string(),
   startTime: z.string().datetime(),
   endTime: z.string().datetime(),
-  ticleStatus: z.enum([TicleStatus.CLOSED, TicleStatus.OPEN]),
+  ticleStatus: z.enum([TicleStatus.CLOSED, TicleStatus.OPEN, TicleStatus.IN_PROGRESS]),
   createdAt: z.string().datetime(),
   tags: z.array(z.string()),
   speakerImgUrl: z.string().url(),

--- a/packages/types/src/ticle/ticleStatus.ts
+++ b/packages/types/src/ticle/ticleStatus.ts
@@ -1,5 +1,6 @@
 export const TicleStatus = {
   OPEN: 'open',
+  IN_PROGRESS: 'in_progress',
   CLOSED: 'closed',
 } as const;
 

--- a/packages/types/src/ticle/ticleStatus.ts
+++ b/packages/types/src/ticle/ticleStatus.ts
@@ -1,6 +1,6 @@
 export const TicleStatus = {
   OPEN: 'open',
-  IN_PROGRESS: 'in_progress',
+  IN_PROGRESS: 'inProgress',
   CLOSED: 'closed',
 } as const;
 


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat] {제목~~} -->
<!-- Reviewer, Assignees, Label 붙이기 -->

## 관련 이슈 번호

<!-- 이슈를 닫지 않는다면 이유 작성하기 -->

- close #318 

## 작업 내용
- ticle 시작/종료 판단을 위해 ticle status에 In_progress를 추가했습니다.

## PR 포인트

## 고민과 학습내용
```ts
export const TicleStatus = {
  OPEN: 'open',
  IN_PROGRESS: 'inProgress',
  CLOSED: 'closed',
} as const;

export type TicleStatus = (typeof TicleStatus)[keyof typeof TicleStatus];
```
티클 생성 하면 status default가 open 상태로 생성됩니다.
발표자가 티클 시작하면 status가 In_progress로 발표자, 참여자 모두 바껴야합니다.
발표자가 티클 종료하면 status가 closed로 바껴야합니다.
참여자는 open인 상태와 closed상태에는 참여하기 버튼이 disabled되어야 합니다.

+ 테스트에 추가적으로 발견한 ticle 생성시에 userId가 없어도 되는 문제는 성하님이 만들어두셨던 getUserByID함수를 붙여서 바로 해결했습니다. 다른 함수에는 추가적으로 안붙어도 되는 것도 확인했습니당~!
## 스크린샷
