### PR TITLE
[Feat] 티클 상태에 따른 조건부 처리, 티클 시작/종료 API 연결

### DIFF
--- a/apps/api/src/ticle/dto/ticleDetailDto.ts
+++ b/apps/api/src/ticle/dto/ticleDetailDto.ts
@@ -1,4 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
+import { TicleStatus } from '@repo/types';
 
 export class TickleDetailResponseDto {
   @ApiProperty({
@@ -74,4 +75,10 @@ export class TickleDetailResponseDto {
     description: '이미 참가신청을 했는지 여부',
   })
   alreadyApplied: boolean;
+
+  @ApiProperty({
+    example: 'inProgress',
+    description: '티클의 상태',
+  })
+  ticleStatus: TicleStatus;
 }

--- a/apps/api/src/ticle/ticle.service.ts
+++ b/apps/api/src/ticle/ticle.service.ts
@@ -206,7 +206,7 @@ export class TicleService {
       .createQueryBuilder('ticle')
       .select('COUNT(*) as count')
       .where('ticle.ticleStatus = :status', {
-        status: isOpen ? TicleStatus.OPEN : TicleStatus.CLOSED,
+        status: isOpen ? TicleStatus.OPEN || TicleStatus.IN_PROGRESS : TicleStatus.CLOSED,
       });
     const totalTicleCount = await countQuery.getRawOne();
 

--- a/apps/api/src/ticle/ticle.service.ts
+++ b/apps/api/src/ticle/ticle.service.ts
@@ -205,8 +205,8 @@ export class TicleService {
     const countQuery = this.ticleRepository
       .createQueryBuilder('ticle')
       .select('COUNT(*) as count')
-      .where('ticle.ticleStatus = :status', {
-        status: isOpen ? TicleStatus.OPEN || TicleStatus.IN_PROGRESS : TicleStatus.CLOSED,
+      .where('ticle.ticleStatus IN (:...statuses)', {
+        status: isOpen ? [TicleStatus.OPEN, TicleStatus.IN_PROGRESS] : [TicleStatus.CLOSED],
       });
     const totalTicleCount = await countQuery.getRawOne();
 

--- a/apps/web/src/api/dashboard.ts
+++ b/apps/web/src/api/dashboard.ts
@@ -27,7 +27,7 @@ const getApplicantsTicle = async (ticleId: string) => {
 };
 
 const startTicle = async (ticleId: string) => {
-  const { data } = await axiosInstance.post('/dashboard/start', { ticleId });
+  const { data } = await axiosInstance.post(`/dashboard/${ticleId}/start`);
 
   return data;
 };

--- a/apps/web/src/api/live.ts
+++ b/apps/web/src/api/live.ts
@@ -1,0 +1,7 @@
+import axiosInstance from './axios';
+
+export const endTicle = async (ticleId: string) => {
+  const { data } = await axiosInstance.post(`/dashboard/${ticleId}/end`);
+
+  return data;
+};

--- a/apps/web/src/components/dashboard/apply/TicleInfoCard.tsx
+++ b/apps/web/src/components/dashboard/apply/TicleInfoCard.tsx
@@ -48,7 +48,7 @@ function TicleInfoCard({
             <span className="text-body1 text-main">{`${dateStr} ${timeRangeStr}`}</span>
           </div>
         </div>
-        <Button disabled={status === 'closed'} onClick={handleTicleParticipate}>
+        <Button disabled={status === 'closed'} onClick={handleTicleParticipate} className="w-36">
           {status === 'closed' ? '종료된 티클' : '티클 참여하기'}
         </Button>
       </div>

--- a/apps/web/src/components/dashboard/apply/TicleInfoCard.tsx
+++ b/apps/web/src/components/dashboard/apply/TicleInfoCard.tsx
@@ -10,7 +10,7 @@ interface TicleInfoCardProps {
   ticleTitle: string;
   startTime: string;
   endTime: string;
-  status: 'closed' | 'open';
+  status: 'closed' | 'open' | 'inProgress';
 }
 
 function TicleInfoCard({
@@ -48,9 +48,8 @@ function TicleInfoCard({
             <span className="text-body1 text-main">{`${dateStr} ${timeRangeStr}`}</span>
           </div>
         </div>
-
         <Button disabled={status === 'closed'} onClick={handleTicleParticipate}>
-          티클 참여하기
+          {status === 'closed' ? '종료된 티클' : '티클 참여하기'}
         </Button>
       </div>
     </Link>

--- a/apps/web/src/components/dashboard/open/TicleInfoCard.tsx
+++ b/apps/web/src/components/dashboard/open/TicleInfoCard.tsx
@@ -3,7 +3,7 @@ import { MouseEvent } from 'react';
 
 import PersonFilledIc from '@/assets/icons/person-filled.svg?react';
 import Button from '@/components/common/Button';
-import { useApplicantsTicle } from '@/hooks/api/dashboard';
+import { useApplicantsTicle, useStartTicle } from '@/hooks/api/dashboard';
 import useModal from '@/hooks/useModal';
 import { formatDateTimeRange } from '@/utils/date';
 
@@ -21,14 +21,16 @@ function TicleInfoCard({ ticleId, ticleTitle, startTime, endTime, status }: Ticl
   const { isOpen, onOpen, onClose } = useModal();
 
   const { data: applicantsData } = useApplicantsTicle(ticleId.toString());
+  const { mutate: ticleStartMutate } = useStartTicle();
   const { dateStr, timeRangeStr } = formatDateTimeRange(startTime, endTime);
 
   const navigate = useNavigate();
 
   if (!applicantsData) return;
 
-  const handleTicleParticipate = (e: MouseEvent<HTMLButtonElement>) => {
+  const handleTicleStart = (e: MouseEvent<HTMLButtonElement>) => {
     e.preventDefault();
+    ticleStartMutate(ticleId.toString());
     navigate({ to: `/live/${ticleId}` });
   };
 
@@ -63,7 +65,7 @@ function TicleInfoCard({ ticleId, ticleTitle, startTime, endTime, status }: Ticl
               <PersonFilledIc className="fill-primary" />
             </div>
           </button>
-          <Button disabled={status === 'closed'} onClick={handleTicleParticipate}>
+          <Button disabled={status === 'closed'} onClick={handleTicleStart}>
             {status === 'closed' ? '종료된 티클' : '티클 시작하기'}
           </Button>
         </div>

--- a/apps/web/src/components/dashboard/open/TicleInfoCard.tsx
+++ b/apps/web/src/components/dashboard/open/TicleInfoCard.tsx
@@ -68,6 +68,7 @@ function TicleInfoCard({ ticleId, ticleTitle, startTime, endTime, status }: Ticl
           <Button
             disabled={status === 'closed' || status === 'inProgress'}
             onClick={handleTicleStart}
+            className="w-36"
           >
             {status === 'closed'
               ? '종료된 티클'

--- a/apps/web/src/components/dashboard/open/TicleInfoCard.tsx
+++ b/apps/web/src/components/dashboard/open/TicleInfoCard.tsx
@@ -65,8 +65,15 @@ function TicleInfoCard({ ticleId, ticleTitle, startTime, endTime, status }: Ticl
               <PersonFilledIc className="fill-primary" />
             </div>
           </button>
-          <Button disabled={status === 'closed'} onClick={handleTicleStart}>
-            {status === 'closed' ? '종료된 티클' : '티클 시작하기'}
+          <Button
+            disabled={status === 'closed' || status === 'inProgress'}
+            onClick={handleTicleStart}
+          >
+            {status === 'closed'
+              ? '종료된 티클'
+              : status === 'inProgress'
+                ? '시작된 티클'
+                : '티클 시작하기'}
           </Button>
         </div>
         {isOpen && (

--- a/apps/web/src/components/dashboard/open/TicleInfoCard.tsx
+++ b/apps/web/src/components/dashboard/open/TicleInfoCard.tsx
@@ -14,7 +14,7 @@ interface TicleInfoCardProps {
   ticleTitle: string;
   startTime: string;
   endTime: string;
-  status: 'closed' | 'open';
+  status: 'closed' | 'open' | 'inProgress';
 }
 
 function TicleInfoCard({ ticleId, ticleTitle, startTime, endTime, status }: TicleInfoCardProps) {
@@ -64,7 +64,7 @@ function TicleInfoCard({ ticleId, ticleTitle, startTime, endTime, status }: Ticl
             </div>
           </button>
           <Button disabled={status === 'closed'} onClick={handleTicleParticipate}>
-            티클 시작하기
+            {status === 'closed' ? '종료된 티클' : '티클 시작하기'}
           </Button>
         </div>
         {isOpen && (

--- a/apps/web/src/components/live/ControlBar/index.tsx
+++ b/apps/web/src/components/live/ControlBar/index.tsx
@@ -12,6 +12,7 @@ import ToggleButton from '@/components/live/ControlBar/ToggleButton';
 import ExitDialog from '@/components/live/ExitDialog';
 import { useLocalStreamAction, useLocalStreamState } from '@/contexts/localStream/context';
 import { useMediasoupAction, useMediasoupState } from '@/contexts/mediasoup/context';
+import { useEndTicle } from '@/hooks/api/live';
 import { useTicle } from '@/hooks/api/ticle';
 import useModal from '@/hooks/useModal';
 
@@ -26,7 +27,9 @@ const ControlBar = () => {
     useLocalStreamAction();
 
   const { ticleId } = useParams({ from: '/_authenticated/live/$ticleId' });
+
   const { data: ticleData } = useTicle(ticleId);
+  const { mutate: endTicleMutate } = useEndTicle();
   const isOwner = ticleData?.isOwner || false;
 
   const toggleScreenShare = async () => {
@@ -70,6 +73,7 @@ const ControlBar = () => {
   const handleExit = () => {
     if (isOwner) {
       socketRef.current?.emit(SOCKET_EVENTS.closeRoom);
+      endTicleMutate(ticleId);
     }
 
     disconnect();

--- a/apps/web/src/components/live/ControlBar/index.tsx
+++ b/apps/web/src/components/live/ControlBar/index.tsx
@@ -1,3 +1,4 @@
+import { useParams } from '@tanstack/react-router';
 import { SOCKET_EVENTS } from '@repo/mediasoup';
 
 import CameraOffIc from '@/assets/icons/camera-off.svg?react';
@@ -11,6 +12,7 @@ import ToggleButton from '@/components/live/ControlBar/ToggleButton';
 import ExitDialog from '@/components/live/ExitDialog';
 import { useLocalStreamAction, useLocalStreamState } from '@/contexts/localStream/context';
 import { useMediasoupAction, useMediasoupState } from '@/contexts/mediasoup/context';
+import { useTicle } from '@/hooks/api/ticle';
 import useModal from '@/hooks/useModal';
 
 const ControlBar = () => {
@@ -22,6 +24,10 @@ const ControlBar = () => {
   const { disconnect } = useMediasoupAction();
   const { closeStream, pauseStream, resumeStream, startScreenStream, closeScreenStream } =
     useLocalStreamAction();
+
+  const { ticleId } = useParams({ from: '/_authenticated/live/$ticleId' });
+  const { data: ticleData } = useTicle(ticleId);
+  const isOwner = ticleData?.isOwner || false;
 
   const toggleScreenShare = async () => {
     const { paused, stream } = screen;
@@ -61,7 +67,7 @@ const ControlBar = () => {
     }
   };
 
-  const handleExit = (isOwner: boolean) => {
+  const handleExit = () => {
     if (isOwner) {
       socketRef.current?.emit(SOCKET_EVENTS.closeRoom);
     }
@@ -93,7 +99,7 @@ const ControlBar = () => {
         <ToggleButton type="exit" ActiveIcon={ExitIc} InactiveIcon={ExitIc} onToggle={onOpen} />
       </div>
       {isOpen && (
-        <ExitDialog isOpen={isOpen} isOwner={false} handleExit={handleExit} onClose={onClose} />
+        <ExitDialog isOpen={isOpen} isOwner={isOwner} handleExit={handleExit} onClose={onClose} />
       )}
     </>
   );

--- a/apps/web/src/components/live/ControlBar/index.tsx
+++ b/apps/web/src/components/live/ControlBar/index.tsx
@@ -1,4 +1,3 @@
-import { useParams } from '@tanstack/react-router';
 import { SOCKET_EVENTS } from '@repo/mediasoup';
 
 import CameraOffIc from '@/assets/icons/camera-off.svg?react';
@@ -12,11 +11,14 @@ import ToggleButton from '@/components/live/ControlBar/ToggleButton';
 import ExitDialog from '@/components/live/ExitDialog';
 import { useLocalStreamAction, useLocalStreamState } from '@/contexts/localStream/context';
 import { useMediasoupAction, useMediasoupState } from '@/contexts/mediasoup/context';
-import { useEndTicle } from '@/hooks/api/live';
-import { useTicle } from '@/hooks/api/ticle';
 import useModal from '@/hooks/useModal';
 
-const ControlBar = () => {
+interface ControlBarProps {
+  isOwner: boolean;
+  onTicleEnd: () => void;
+}
+
+const ControlBar = ({ isOwner, onTicleEnd }: ControlBarProps) => {
   const { isOpen, onClose, onOpen } = useModal();
 
   const { socketRef } = useMediasoupState();
@@ -25,12 +27,6 @@ const ControlBar = () => {
   const { disconnect } = useMediasoupAction();
   const { closeStream, pauseStream, resumeStream, startScreenStream, closeScreenStream } =
     useLocalStreamAction();
-
-  const { ticleId } = useParams({ from: '/_authenticated/live/$ticleId' });
-
-  const { data: ticleData } = useTicle(ticleId);
-  const { mutate: endTicleMutate } = useEndTicle();
-  const isOwner = ticleData?.isOwner || false;
 
   const toggleScreenShare = async () => {
     const { paused, stream } = screen;
@@ -73,7 +69,7 @@ const ControlBar = () => {
   const handleExit = () => {
     if (isOwner) {
       socketRef.current?.emit(SOCKET_EVENTS.closeRoom);
-      endTicleMutate(ticleId);
+      onTicleEnd();
     }
 
     disconnect();

--- a/apps/web/src/components/live/index.tsx
+++ b/apps/web/src/components/live/index.tsx
@@ -31,7 +31,8 @@ function MediaContainer() {
   return (
     <div className="flex h-dvh flex-col justify-between gap-y-4 bg-black">
       <StreamView />
-      <footer className="flex w-full justify-end gap-4 px-8 pb-4 text-white">
+      <footer className="flex w-full items-center justify-between gap-4 px-8 pb-4 text-white">
+        <span className="text-body1 text-white">{ticleData?.title}</span>
         <ControlBar isOwner={isOwner} onTicleEnd={hanleTicleEnd} />
       </footer>
     </div>

--- a/apps/web/src/components/live/index.tsx
+++ b/apps/web/src/components/live/index.tsx
@@ -1,15 +1,38 @@
+import { useNavigate, useParams } from '@tanstack/react-router';
+import { useEffect } from 'react';
+
 import ControlBar from '@/components/live/ControlBar';
 import StreamView from '@/components/live/StreamView';
+import { useEndTicle } from '@/hooks/api/live';
+import { useTicle } from '@/hooks/api/ticle';
 import useMediasoup from '@/hooks/mediasoup/useMediasoup';
 
 function MediaContainer() {
   useMediasoup();
 
+  const { ticleId } = useParams({ from: '/_authenticated/live/$ticleId' });
+  const navigate = useNavigate({ from: '/live/$ticleId' });
+
+  const { data: ticleData } = useTicle(ticleId);
+  const { mutate: endTicleMutate } = useEndTicle();
+
+  const isOwner = ticleData?.isOwner || false;
+  const hanleTicleEnd = () => {
+    endTicleMutate(ticleId);
+  };
+
+  useEffect(() => {
+    if (ticleData?.ticleStatus === 'closed') {
+      alert('종료된 티클입니다.'); // TODO: toast로 교체
+      navigate({ to: '/' });
+    }
+  }, [ticleData?.ticleStatus, navigate]);
+
   return (
     <div className="flex h-dvh flex-col justify-between gap-y-4 bg-black">
       <StreamView />
       <footer className="flex w-full justify-end gap-4 px-8 pb-4 text-white">
-        <ControlBar />
+        <ControlBar isOwner={isOwner} onTicleEnd={hanleTicleEnd} />
       </footer>
     </div>
   );

--- a/apps/web/src/components/ticle/detail/CtaButton.tsx
+++ b/apps/web/src/components/ticle/detail/CtaButton.tsx
@@ -1,0 +1,77 @@
+import { ReactNode } from 'react';
+import { TicleStatus } from '@repo/types';
+
+import TrashIc from '@/assets/icons/trash.svg?react';
+import Button from '@/components/common/Button';
+
+type ButtonState = 'owner' | 'applied' | 'closed' | 'default';
+
+interface ButtonConfig {
+  onClick: (() => void) | undefined;
+  disabled: boolean;
+  content: ReactNode;
+}
+
+type ButtonConfigMap = Record<ButtonState, ButtonConfig>;
+
+interface CtaButtonProps {
+  isOwner: boolean;
+  alreadyApplied: boolean;
+  ticleStatus: TicleStatus;
+  onDelete: () => void;
+  onApply: () => void;
+}
+
+function CtaButton({ isOwner, alreadyApplied, ticleStatus, onDelete, onApply }: CtaButtonProps) {
+  const getButtonState = (): ButtonState => {
+    if (isOwner) {
+      return 'owner';
+    }
+    if (alreadyApplied) {
+      return 'applied';
+    }
+    if (ticleStatus === 'closed') {
+      return 'closed';
+    }
+    return 'default';
+  };
+
+  const buttonConfig: ButtonConfigMap = {
+    owner: {
+      onClick: onDelete,
+      disabled: false,
+      content: (
+        <span className="flex items-center gap-1">
+          티클 삭제하기
+          <TrashIc className="fill-white" />
+        </span>
+      ),
+    },
+    applied: {
+      onClick: undefined,
+      disabled: true,
+      content: '신청 완료',
+    },
+    closed: {
+      onClick: undefined,
+      disabled: true,
+      content: '종료된 티클',
+    },
+    default: {
+      onClick: onApply,
+      disabled: false,
+      content: '티클 신청하기',
+    },
+  };
+
+  const buttonState = getButtonState();
+  const config = buttonConfig[buttonState];
+
+  return (
+    <Button onClick={config.onClick} disabled={config.disabled}>
+      {config.content}
+    </Button>
+  );
+}
+
+export default CtaButton;

--- a/apps/web/src/components/ticle/detail/index.tsx
+++ b/apps/web/src/components/ticle/detail/index.tsx
@@ -2,14 +2,14 @@ import { useParams } from '@tanstack/react-router';
 
 import CalendarIc from '@/assets/icons/calendar.svg?react';
 import ClockIc from '@/assets/icons/clock.svg?react';
-import TrashIc from '@/assets/icons/trash.svg?react';
 import Avatar from '@/components/common/Avatar';
 import Badge from '@/components/common/Badge';
-import Button from '@/components/common/Button';
 import UserProfileDialog from '@/components/user/UserProfileDialog';
 import { useApplyTicle, useDeleteTicle, useTicle } from '@/hooks/api/ticle';
 import useModal from '@/hooks/useModal';
 import { formatDateTimeRange } from '@/utils/date';
+
+import CtaButton from './CtaButton';
 
 function Detail() {
   const { ticleId } = useParams({ from: '/_authenticated/ticle/$ticleId' });
@@ -84,18 +84,13 @@ function Detail() {
           </div>
         </div>
       </div>
-      {data.isOwner ? (
-        <Button onClick={handleDeleteButtonClick}>
-          <span className="flex items-center gap-1">
-            티클 삭제하기
-            <TrashIc className="fill-white" />
-          </span>
-        </Button>
-      ) : (
-        <Button onClick={handleApplyButtonClick} disabled={data.alreadyApplied}>
-          {data.alreadyApplied ? '신청 완료' : '티클 신청하기'}
-        </Button>
-      )}
+      <CtaButton
+        isOwner={data.isOwner}
+        alreadyApplied={data.alreadyApplied}
+        ticleStatus={data.ticleStatus}
+        onApply={handleApplyButtonClick}
+        onDelete={handleDeleteButtonClick}
+      />
     </div>
   );
 }

--- a/apps/web/src/components/ticle/detail/index.tsx
+++ b/apps/web/src/components/ticle/detail/index.tsx
@@ -34,7 +34,7 @@ function Detail() {
   const { dateStr, timeRangeStr } = formatDateTimeRange(data.startTime, data.endTime);
   return (
     <div className="flex flex-col items-end gap-9">
-      <div className="surface-white flex w-[49.5rem] flex-col gap-9 rounded-lg border border-main p-10 shadow-normal">
+      <div className="flex w-[49.5rem] flex-col gap-9 rounded-lg border border-main bg-white p-10 shadow-normal">
         <div className="flex flex-col gap-2">
           <h1 className="w-full text-head1 text-main">{data.title}</h1>
           <div className="flex gap-2.5">

--- a/apps/web/src/hooks/api/dashboard.ts
+++ b/apps/web/src/hooks/api/dashboard.ts
@@ -33,9 +33,8 @@ export const useStartTicle = () => {
 
   return useMutation({
     mutationFn: startTicle,
-    onSuccess: (_, ticleId) => {
+    onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['appliedTicleList'] });
-      queryClient.invalidateQueries({ queryKey: ['applicantsTicle', ticleId] });
     },
   });
 };

--- a/apps/web/src/hooks/api/live.ts
+++ b/apps/web/src/hooks/api/live.ts
@@ -7,8 +7,10 @@ export const useEndTicle = () => {
 
   return useMutation({
     mutationFn: endTicle,
-    onSuccess: () => {
+    onSuccess: (_, ticleId) => {
       queryClient.invalidateQueries({ queryKey: ['appliedTicleList'] });
+      queryClient.invalidateQueries({ queryKey: ['ticleList'] });
+      queryClient.invalidateQueries({ queryKey: ['ticle', ticleId] });
     },
   });
 };

--- a/apps/web/src/hooks/api/live.ts
+++ b/apps/web/src/hooks/api/live.ts
@@ -1,0 +1,14 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { endTicle } from '@/api/live';
+
+export const useEndTicle = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: endTicle,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['appliedTicleList'] });
+    },
+  });
+};


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat] {제목~~} -->
<!-- Reviewer, Assignees, Label 붙이기 -->

## 관련 이슈 번호

<!-- 이슈를 닫지 않는다면 이유 작성하기 -->

- close #24
- close #27

## 작업 내용
- 새로 추가된 'inProgress' 상태에 대한 조건부 처리
  - 대시보드 개설한 티클에서 inProgress 상태일 경우 '시작된 티클'이라고 띄우고 disabled 처리
- 개설한 티클에서 '티클 시작하기' 누를 때 티클 시작 API 요청
- 발표자와 참여자에 대한 티클 종료 모달 분기 처리
- 티클 종료시 티클 종료 API 요청 (발표자만 가능)
- 스트리밍 페이지에서 티클 제목 표시

## PR 포인트
@Jieun1ee 
티클 전체 조회에서, isOpen을 true로 요청했을 때 open 상태인 것과 inProgress 상태인 것 둘다 보내주어야하는데 지금 open만 보내주고있는 것 같아서 수정했습니다! 혹시 잘못 고친거라면 말씀해주세요!!
```ts
 const countQuery = this.ticleRepository
      .createQueryBuilder('ticle')
      .select('COUNT(*) as count')
      .where('ticle.ticleStatus = :status', {
        // status: isOpen ? TicleStatus.OPEN : TicleStatus.CLOSED, <- 이전 코드
        status: isOpen ? TicleStatus.OPEN || TicleStatus.IN_PROGRESS : TicleStatus.CLOSED, // <- 바꾼 코드
      });
    const totalTicleCount = await countQuery.getRawOne();
```


## 고민과 학습내용

## 스크린샷
### 종료 상태에 대한 필터링 잘 됩니다
![image](https://github.com/user-attachments/assets/966c3c63-897d-4a5a-b8ef-bb5cc2fc6ce5)
![image](https://github.com/user-attachments/assets/7ea74142-54a6-4951-b105-eeee07bf143b)
![image](https://github.com/user-attachments/assets/16717ace-154e-44a2-be2d-aba29af0d94b)

### 티클 시작하기 누르고나면 이렇게 됩니다
![image](https://github.com/user-attachments/assets/68832c01-c5aa-495f-b1fc-41298112808d)

### 티클 종료 시나리오

https://github.com/user-attachments/assets/fba3a696-595f-414c-b82f-cfaf9bc98f82

위 영상에서, 방장이 '모두에 대해 티클 종료'를 눌렀을 때 단순히 ticleStatus만 변경되므로,
참가자 입장에서는 아무 일도 일어나지 않고 새로고침을 눌렀을 때 비로소 ticleStatus가 closed되었다는 정보를 받아서 처리하는 모습입니다.

>[!IMPORTANT] 
> **발표자가 티클 종료시 서버에서 처리 필요**
> 발표자가 '모두에 대해 티클 종료'를 누르면 티클 종료 API 요청을 하고, `closeRoom` 소켓 이벤트를 emit 하고 있습니다.
> 그러나 현재 `closeRoom` 이벤트 발생시 아무것도 처리되는 것이 없기 때문에, 참가자들은 티클이 종료되어도 계속해서 방에 남아있게 됩니다.
> 따라서 `closeRoom` 이벤트 발생시 참가자에 대한 연결을 모두 해제하고 페이지를 이동시키는 추가 로직이 필요해보입니다.

### 티클 제목 표시
![image](https://github.com/user-attachments/assets/073537e6-bdc2-4c88-9844-004c0be1d554)

사소하지만 스트리밍에서 티클 제목도 표시하도록 했습니다~ (하단 좌측)