### PR TITLE
[Feat] Observer Pattern을 통한 Toast Message 추가

### DIFF
--- a/apps/web/.eslintrc.cjs
+++ b/apps/web/.eslintrc.cjs
@@ -9,6 +9,7 @@ module.exports = {
   root: true,
   extends: [
     require.resolve('@repo/lint'),
+    'prettier/prettier',
     'plugin:react/recommended',
     'plugin:react-hooks/recommended',
     // 'plugin:jsx-a11y/recommended',

--- a/apps/web/src/components/toast/Toast.tsx
+++ b/apps/web/src/components/toast/Toast.tsx
@@ -1,0 +1,51 @@
+import { cva } from 'class-variance-authority';
+import { ReactNode, useEffect } from 'react';
+
+import ToastTransition from '@/components/toast/ToastTransition';
+import { ToastProps } from '@/core/toast/type';
+import useToast from '@/hooks/toast/useToast';
+
+const containerVariants = cva(
+  '[&.bounce-enter]:animate-bounce-in-bottom [&.bounce-exit]:animate-bounce-out-bottom z-0 mb-4 flex max-h-[800px] min-h-16 cursor-pointer justify-between overflow-hidden rounded-md bg-[#000000b3] text-white shadow-md',
+  {
+    variants: {
+      closeOnClick: {
+        true: 'pointer',
+        false: 'default',
+      },
+    },
+  }
+);
+const Toast = (props: ToastProps) => {
+  const { toastRef, eventHandlers } = useToast(props);
+  const { autoClose, children, closeToast, deleteToast, toastId, isIn, closeOnClick } = props;
+
+  useEffect(() => {
+    const timeout = setTimeout(() => {
+      if (!isIn) return;
+
+      closeToast();
+    }, autoClose);
+
+    return () => {
+      clearTimeout(timeout);
+    };
+  }, []);
+
+  return (
+    <ToastTransition isIn={isIn} done={deleteToast} nodeRef={toastRef}>
+      <div
+        ref={toastRef}
+        id={String(toastId)}
+        className={containerVariants({ closeOnClick })}
+        {...eventHandlers}
+      >
+        <div className="mx-0 my-auto flex flex-1 items-center justify-center px-3 py-2 text-sm">
+          <div className="flex items-center justify-center gap-2">{children as ReactNode}</div>
+        </div>
+      </div>
+    </ToastTransition>
+  );
+};
+
+export default Toast;

--- a/apps/web/src/components/toast/Toast.tsx
+++ b/apps/web/src/components/toast/Toast.tsx
@@ -6,7 +6,7 @@ import { ToastProps } from '@/core/toast/type';
 import useToast from '@/hooks/toast/useToast';
 
 const containerVariants = cva(
-  '[&.bounce-enter]:animate-bounce-in-bottom [&.bounce-exit]:animate-bounce-out-bottom z-0 mb-4 flex max-h-[800px] min-h-16 cursor-pointer justify-between overflow-hidden rounded-md bg-[#000000b3] text-white shadow-md',
+  'z-0 mb-4 flex max-h-[800px] min-h-16 cursor-pointer justify-between overflow-hidden rounded-md bg-[#000000b3] text-white shadow-md [&.bounce-enter]:animate-bounce-in-bottom [&.bounce-exit]:animate-bounce-out-bottom',
   {
     variants: {
       closeOnClick: {

--- a/apps/web/src/components/toast/ToastContainer.tsx
+++ b/apps/web/src/components/toast/ToastContainer.tsx
@@ -1,0 +1,40 @@
+import Toast from '@/components/toast/Toast';
+import { ToastCommonOptions } from '@/core/toast/type';
+import useToastContainer from '@/hooks/toast/useToastContainer';
+import cn from '@/utils/cn';
+
+const CONTAINER_CLASS =
+  'fixed z-50 min-w-[200px] max-w-[320px] p-1 text-white top-2.5 left-1/2 transform -translate-x-1/2';
+
+export type ToastContainerProps = ToastCommonOptions;
+
+const ToastContainer = ({ autoClose = 2000, closeOnClick = true }: ToastContainerProps) => {
+  const { getToastToRender, containerRef, isToastActive } = useToastContainer({
+    autoClose,
+    closeOnClick,
+  });
+
+  return (
+    <div ref={containerRef} className={CONTAINER_CLASS}>
+      {getToastToRender((toastList) => {
+        return (
+          <div className={cn(CONTAINER_CLASS, 'bottom-0 transition-all delay-300')}>
+            {toastList.map(({ content, props: toastProps }) => {
+              return (
+                <Toast
+                  {...toastProps}
+                  key={`toast-${toastProps.key}`}
+                  isIn={isToastActive(toastProps.toastId)}
+                >
+                  {content}
+                </Toast>
+              );
+            })}
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+export { ToastContainer };

--- a/apps/web/src/components/toast/ToastContainer.tsx
+++ b/apps/web/src/components/toast/ToastContainer.tsx
@@ -16,23 +16,19 @@ const ToastContainer = ({ autoClose = 2000, closeOnClick = true }: ToastContaine
 
   return (
     <div ref={containerRef} className={CONTAINER_CLASS}>
-      {getToastToRender((toastList) => {
-        return (
-          <div className={cn(CONTAINER_CLASS, 'bottom-0 transition-all delay-300')}>
-            {toastList.map(({ content, props: toastProps }) => {
-              return (
-                <Toast
-                  {...toastProps}
-                  key={`toast-${toastProps.key}`}
-                  isIn={isToastActive(toastProps.toastId)}
-                >
-                  {content}
-                </Toast>
-              );
-            })}
-          </div>
-        );
-      })}
+      {getToastToRender((toastList) => (
+        <div className={cn(CONTAINER_CLASS, 'bottom-0 transition-all delay-300')}>
+          {toastList.map(({ content, props: toastProps }) => (
+            <Toast
+              {...toastProps}
+              key={`toast-${toastProps.key}`}
+              isIn={isToastActive(toastProps.toastId)}
+            >
+              {content}
+            </Toast>
+          ))}
+        </div>
+      ))}
     </div>
   );
 };

--- a/apps/web/src/components/toast/ToastTransition.tsx
+++ b/apps/web/src/components/toast/ToastTransition.tsx
@@ -1,0 +1,72 @@
+import { ReactNode, RefObject, useEffect, useLayoutEffect, useRef } from 'react';
+
+import { ENTER_CLASSNAME, EXIT_CLASSNAME, TOAST_COLLAPSE_DURATION } from '@/constants/toast';
+import { collapseToast } from '@/utils/toast/collapseToast';
+
+type AnimationStep = 'enter' | 'exit';
+
+export interface ToastTransitionProps {
+  isIn: boolean;
+  done: () => void;
+  nodeRef: RefObject<HTMLElement>;
+  children?: ReactNode;
+  collapseDuration?: number;
+}
+
+const ToastTransition = ({
+  isIn,
+  done,
+  nodeRef,
+  children,
+  collapseDuration = TOAST_COLLAPSE_DURATION,
+}: ToastTransitionProps) => {
+  const animationStep = useRef<AnimationStep>('enter');
+
+  useLayoutEffect(() => {
+    const node = nodeRef.current;
+
+    if (!node) return;
+
+    const onEntered = (e: AnimationEvent) => {
+      if (e.target !== nodeRef.current) return;
+
+      node.removeEventListener('animationend', onEntered);
+      node.removeEventListener('animationcancel', onEntered);
+
+      if (animationStep.current !== 'enter' || e.type === 'animationcancel') return;
+
+      node.classList.remove(ENTER_CLASSNAME);
+    };
+
+    const onEnter = () => {
+      node.classList.add(ENTER_CLASSNAME);
+      node.addEventListener('animationend', onEntered);
+      node.addEventListener('animationcancel', onEntered);
+    };
+
+    onEnter();
+  }, [nodeRef]);
+
+  useEffect(() => {
+    const node = nodeRef.current;
+
+    if (isIn || !node) return;
+
+    const onExited = () => {
+      node.removeEventListener('animationend', onExited);
+      collapseToast(node, done, collapseDuration);
+    };
+
+    const onExit = () => {
+      animationStep.current = 'exit';
+      node.classList.add(EXIT_CLASSNAME);
+      node.addEventListener('animationend', onExited);
+    };
+
+    onExit();
+  }, [isIn]);
+
+  return <>{children}</>;
+};
+
+export default ToastTransition;

--- a/apps/web/src/constants/toast.ts
+++ b/apps/web/src/constants/toast.ts
@@ -1,0 +1,3 @@
+export const TOAST_COLLAPSE_DURATION = 300;
+export const ENTER_CLASSNAME = 'bounce-enter';
+export const EXIT_CLASSNAME = 'bounce-exit';

--- a/apps/web/src/core/toast/eventManager.ts
+++ b/apps/web/src/core/toast/eventManager.ts
@@ -1,0 +1,59 @@
+import {
+  ToastContent,
+  NotValidatedToastProps,
+  ToastCallback,
+  OnShowCallback,
+  OnWillUnmountCallback,
+  ToastEvent,
+} from '@/core/toast/type';
+
+class EventManager {
+  list: Map<ToastEvent, ToastCallback[]> = new Map();
+
+  on(event: 'show', callback: OnShowCallback): EventManager;
+  on(event: 'willUnmount', callback: OnWillUnmountCallback): EventManager;
+  on(event: ToastEvent, callback: ToastCallback): EventManager {
+    const callbacks = this.list.get(event) ?? [];
+
+    callbacks.push(callback);
+    this.list.set(event, callbacks);
+
+    return this;
+  }
+
+  off(event: ToastEvent, callback?: ToastCallback): EventManager {
+    if (!callback) {
+      this.list.delete(event);
+    }
+
+    if (callback) {
+      const callbacks = this.list.get(event) ?? [];
+
+      const cb = callbacks.filter((cb) => cb !== callback);
+
+      this.list.set(event, cb);
+
+      return this;
+    }
+
+    return this;
+  }
+
+  emit(event: 'show', content: ToastContent, options: NotValidatedToastProps): void;
+  emit(event: 'willUnmount'): void;
+  emit(event: ToastEvent, ...args: any[]) {
+    const callbacks = this.list.get(event);
+
+    if (!this.list.has(event) || !callbacks) {
+      return;
+    }
+
+    callbacks.forEach((callback: ToastCallback) => {
+      callback(args[0], args[1]);
+    });
+  }
+}
+
+const eventManager = new EventManager();
+
+export { eventManager };

--- a/apps/web/src/core/toast/eventManager.ts
+++ b/apps/web/src/core/toast/eventManager.ts
@@ -41,7 +41,7 @@ class EventManager {
 
   emit(event: 'show', content: ToastContent, options: NotValidatedToastProps): void;
   emit(event: 'willUnmount'): void;
-  emit(event: ToastEvent, ...args: any[]) {
+  emit(event: ToastEvent, ...args: never) {
     const callbacks = this.list.get(event);
 
     if (!this.list.has(event) || !callbacks) {

--- a/apps/web/src/core/toast/index.ts
+++ b/apps/web/src/core/toast/index.ts
@@ -1,0 +1,2 @@
+export * from './eventManager';
+export * from './utils';

--- a/apps/web/src/core/toast/type.ts
+++ b/apps/web/src/core/toast/type.ts
@@ -1,0 +1,38 @@
+import { ReactNode } from 'react';
+
+export type ToastContent = ReactNode;
+
+export type ToastId = number | string;
+
+export interface ToastCommonOptions {
+  autoClose?: number;
+  closeOnClick?: boolean;
+}
+
+export interface ToastOptions extends ToastCommonOptions {
+  toastId?: ToastId;
+}
+
+export interface ToastProps extends ToastOptions {
+  isIn: boolean;
+  toastId: ToastId;
+  key: ToastId;
+  closeToast: () => void;
+  deleteToast: () => void;
+  children?: ToastContent;
+}
+
+export interface NotValidatedToastProps extends Partial<ToastProps> {
+  toastId: ToastId;
+}
+
+export interface Toast {
+  content: ToastContent;
+  props: ToastProps;
+}
+export type ToastEvent = 'show' | 'willUnmount';
+
+export type OnShowCallback = (content: ToastContent, options: NotValidatedToastProps) => void;
+export type OnWillUnmountCallback = () => void;
+
+export type ToastCallback = OnShowCallback | OnWillUnmountCallback;

--- a/apps/web/src/core/toast/utils.ts
+++ b/apps/web/src/core/toast/utils.ts
@@ -1,0 +1,28 @@
+import { ToastContent, ToastOptions, ToastId, NotValidatedToastProps } from '@/core/toast/type';
+
+import { eventManager } from './eventManager';
+
+let TOAST_ID = 1;
+
+const generateToastId = () => {
+  return TOAST_ID++;
+};
+
+const dispatchToast = (content: ToastContent, options: NotValidatedToastProps): ToastId => {
+  eventManager.emit('show', content, options);
+
+  return options.toastId;
+};
+
+const mergeOptions = (options?: ToastOptions): NotValidatedToastProps => {
+  return {
+    ...options,
+    toastId: generateToastId(),
+  };
+};
+
+const toast = (content: ToastContent, options?: ToastOptions) => {
+  return dispatchToast(content, mergeOptions(options));
+};
+
+export { toast };

--- a/apps/web/src/hooks/toast/useToast.ts
+++ b/apps/web/src/hooks/toast/useToast.ts
@@ -1,0 +1,20 @@
+import { useRef, DOMAttributes } from 'react';
+
+import { ToastProps } from '@/core/toast/type';
+
+const useToast = (props: ToastProps) => {
+  const toastRef = useRef<HTMLDivElement>(null);
+  const { closeToast, closeOnClick } = props;
+
+  const eventHandlers: DOMAttributes<HTMLElement> = {};
+
+  if (closeOnClick) {
+    eventHandlers.onClick = () => {
+      closeToast();
+    };
+  }
+
+  return { toastRef, eventHandlers };
+};
+
+export default useToast;

--- a/apps/web/src/hooks/toast/useToastContainer.ts
+++ b/apps/web/src/hooks/toast/useToastContainer.ts
@@ -1,3 +1,4 @@
+/* eslint-disable react-hooks/exhaustive-deps */
 import {
   useEffect,
   useRef,
@@ -21,12 +22,10 @@ import {
 import { canBeRendered, isStr } from '@/utils/toast/typeGuard';
 
 export interface ContainerInstance {
-  toastKey: number;
-  displayedToast: number;
-  props: ToastContainerProps;
-  isToastActive: (toastId: ToastId) => boolean;
-  getToast: (id: ToastId) => Toast | null | undefined;
   count: number;
+  toastKey: number;
+  props: ToastContainerProps;
+  getToast: (id: ToastId) => Toast | null | undefined;
 }
 
 const useToastContainer = (props: ToastContainerProps) => {
@@ -35,11 +34,9 @@ const useToastContainer = (props: ToastContainerProps) => {
   const containerRef = useRef(null);
   const toastToRender = useRef(new Map<ToastId, Toast>()).current;
   const instance = useRef<ContainerInstance>({
-    toastKey: 1,
-    displayedToast: 0,
-    count: 0,
     props,
-    isToastActive,
+    count: 0,
+    toastKey: 1,
     getToast: (id) => toastToRender.get(id),
   }).current;
 
@@ -51,16 +48,9 @@ const useToastContainer = (props: ToastContainerProps) => {
       eventManager.emit('willUnmount');
     };
   }, []);
-
-  useEffect(() => {
-    instance.props = props;
-    instance.isToastActive = isToastActive;
-    instance.displayedToast = toastIds.length;
-  });
-
-  function isToastActive(id: ToastId) {
+  const isToastActive = (id: ToastId) => {
     return toastIds.indexOf(id) !== -1;
-  }
+  };
 
   const removeToast = (toastId?: ToastId) => {
     setToastIds((state) => (!toastId ? [] : state.filter((id) => id !== toastId)));

--- a/apps/web/src/hooks/toast/useToastContainer.ts
+++ b/apps/web/src/hooks/toast/useToastContainer.ts
@@ -1,0 +1,132 @@
+import {
+  useEffect,
+  useRef,
+  useReducer,
+  cloneElement,
+  isValidElement,
+  useState,
+  ReactElement,
+  ReactNode,
+} from 'react';
+
+import { ToastContainerProps } from '@/components/toast/ToastContainer';
+import { eventManager } from '@/core/toast/eventManager';
+import {
+  ToastId,
+  ToastProps,
+  ToastContent,
+  Toast,
+  NotValidatedToastProps,
+} from '@/core/toast/type';
+import { canBeRendered, isStr } from '@/utils/toast/typeGuard';
+
+export interface ContainerInstance {
+  toastKey: number;
+  displayedToast: number;
+  props: ToastContainerProps;
+  isToastActive: (toastId: ToastId) => boolean;
+  getToast: (id: ToastId) => Toast | null | undefined;
+  count: number;
+}
+
+const useToastContainer = (props: ToastContainerProps) => {
+  const [, forceUpdate] = useReducer((x) => x + 1, 0);
+  const [toastIds, setToastIds] = useState<ToastId[]>([]);
+  const containerRef = useRef(null);
+  const toastToRender = useRef(new Map<ToastId, Toast>()).current;
+  const instance = useRef<ContainerInstance>({
+    toastKey: 1,
+    displayedToast: 0,
+    count: 0,
+    props,
+    isToastActive,
+    getToast: (id) => toastToRender.get(id),
+  }).current;
+
+  useEffect(() => {
+    eventManager.on('show', buildToast).on('willUnmount', () => eventManager.off('show'));
+
+    return () => {
+      toastToRender.clear();
+      eventManager.emit('willUnmount');
+    };
+  }, []);
+
+  useEffect(() => {
+    instance.props = props;
+    instance.isToastActive = isToastActive;
+    instance.displayedToast = toastIds.length;
+  });
+
+  function isToastActive(id: ToastId) {
+    return toastIds.indexOf(id) !== -1;
+  }
+
+  const removeToast = (toastId?: ToastId) => {
+    setToastIds((state) => (!toastId ? [] : state.filter((id) => id !== toastId)));
+  };
+
+  const buildToast = (content: ToastContent, options: NotValidatedToastProps) => {
+    if (!canBeRendered(content) || !containerRef.current) return;
+
+    const { toastId } = options;
+    const { props } = instance;
+
+    const closeToast = () => removeToast(toastId);
+    const deleteToast = () => {
+      toastToRender.delete(toastId);
+
+      instance.count -= 1;
+
+      if (instance.count < 0) instance.count = 0;
+
+      forceUpdate();
+    };
+
+    const filteredOptions = Object.fromEntries(
+      Object.entries(options).filter(([_, v]) => v != null)
+    );
+
+    const toastProps = {
+      key: instance.toastKey++,
+      ...props,
+      ...filteredOptions,
+      toastId,
+      closeToast,
+      deleteToast,
+      isIn: false,
+    };
+
+    let toastContent = content;
+
+    if (isValidElement(content) && !isStr(content.type)) {
+      toastContent = cloneElement(content as ReactElement, { closeToast, toastProps });
+    }
+
+    appendToast(toastContent, toastProps);
+
+    instance.count++;
+  };
+
+  const appendToast = (content: ToastContent, props: ToastProps) => {
+    const { toastId } = props;
+
+    toastToRender.set(toastId, { content, props });
+
+    setToastIds((state) => [toastId, ...state]);
+  };
+
+  const getToastToRender = (cb: (toastList: Toast[]) => ReactNode) => {
+    const toRender = Array.from(toastToRender.values()).reverse();
+
+    return cb(toRender);
+  };
+
+  return {
+    getToastToRender,
+    containerRef,
+    isToastActive,
+  };
+};
+
+export default useToastContainer;

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -1,5 +1,7 @@
 import { Outlet, ScrollRestoration, createRootRoute } from '@tanstack/react-router';
 
+import { ToastContainer } from '@/components/toast/ToastContainer';
+
 export const Route = createRootRoute({
   component: RootComponent,
 });
@@ -9,6 +11,7 @@ function RootComponent() {
     <div className="h-full min-h-dvh bg-weak">
       <ScrollRestoration />
       <Outlet />
+      <ToastContainer />
     </div>
   );
 }

--- a/apps/web/src/utils/toast/collapseToast.ts
+++ b/apps/web/src/utils/toast/collapseToast.ts
@@ -1,0 +1,22 @@
+import { TOAST_COLLAPSE_DURATION } from '@/constants/toast';
+
+export const collapseToast = (
+  node: HTMLElement,
+  done: () => void,
+  duration = TOAST_COLLAPSE_DURATION
+) => {
+  const { scrollHeight, style } = node;
+
+  requestAnimationFrame(() => {
+    style.minHeight = 'initial';
+    style.height = `${scrollHeight}px`;
+    style.transition = `all ${duration}ms`;
+
+    requestAnimationFrame(() => {
+      style.height = '0';
+      style.padding = '0';
+      style.margin = '0';
+      setTimeout(done, duration as number);
+    });
+  });
+};

--- a/apps/web/src/utils/toast/typeGuard.ts
+++ b/apps/web/src/utils/toast/typeGuard.ts
@@ -1,0 +1,13 @@
+import { isValidElement } from 'react';
+
+import { ToastContent } from '@/core/toast/type';
+
+export const isNum = (v: unknown): v is number => typeof v === 'number' && !isNaN(v);
+
+export const isStr = (v: unknown): v is string => typeof v === 'string';
+
+export const isFn = (v: unknown): v is (...args: any) => void => typeof v === 'function';
+
+export const canBeRendered = (content: ToastContent) => {
+  return isValidElement(content) || isStr(content) || isFn(content) || isNum(content);
+};

--- a/apps/web/tailwind.config.ts
+++ b/apps/web/tailwind.config.ts
@@ -140,7 +140,9 @@ const tailwindConfig: Config = {
       // animation
       animation: {
         flashWhite: 'flashWhite 1s ease-out infinite alternate',
-        flashPrimary: 'flashPurple 1s ease-out infinite alternate',
+        flashPrimary: 'flashPurple   1s ease-out infinite alternate',
+        'bounce-in-bottom': 'bounceInBottom 300ms both',
+        'bounce-out-bottom': 'bounceOutBottom 300ms both',
       },
 
       // keyframes
@@ -159,6 +161,26 @@ const tailwindConfig: Config = {
           },
           '50%': {
             backgroundColor: 'var(--purple-500)',
+          },
+        },
+        bounceInBottom: {
+          from: {
+            opacity: '0',
+            transform: 'translate3d(0, -30px, 0)',
+          },
+          to: {
+            opacity: '1',
+            transform: 'translate3d(0, 0, 0)',
+          },
+        },
+        bounceOutBottom: {
+          '20%': {
+            opacity: '1',
+            transform: 'translate3d(0, 0, 0)',
+          },
+          to: {
+            opacity: '0',
+            transform: 'translate3d(0, 30px, 0)',
           },
         },
       },


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat] {제목~~} -->
<!-- Reviewer, Assignees, Label 붙이기 -->

## 관련 이슈 번호

- #342
- 에러, 알림 등을 추가하여야하기 때문에 종료하지 않았습니다.

## 작업 내용

- Toast 이벤트를 관리하는 ToastManager 구현
- `toast` 메서드 실행시 ReactNode를 인자로 넘겨 렌더링 실행
- 메시지 생성/종료 시점에 애니메이션 적용

## PR 포인트

[문서화를 진행하였습니다.](https://simeunseo.notion.site/Toast-Message-759b2650191f4402a6574dc13ff9ee89?pvs=4)

## 스크린샷

`toast` 함수의 인자로 ReactNode Type을 넘겨서 실행할 수 있습니다.

```tsx
toast(<div className="text-red-600">Hello World</div>);
toast(<div className="text-blue-600">Hello World</div>);
```

|![화면 기록 2024-12-03 오전 12 01 34](https://github.com/user-attachments/assets/b8fa1d97-321e-4869-a250-00d9d1126465)|![화면 기록 2024-12-03 오전 12 01 16](https://github.com/user-attachments/assets/ef6fd134-712b-4c7d-9d4a-edff0aa439f6)|
|--|--|




