### PR TITLE
[feat] 회의실 전체 종료 로직 구현

### DIFF
--- a/apps/media/src/mediasoup/mediasoup.service.ts
+++ b/apps/media/src/mediasoup/mediasoup.service.ts
@@ -291,4 +291,8 @@ export class MediasoupService implements OnModuleInit {
   resumeConsumers(socketId: string, roomId: string, consumerIds: string[]) {
     return consumerIds.map((consumerId) => this.resumeConsumer(socketId, consumerId, roomId));
   }
+
+  closeRoom(roomId: string) {
+    this.roomService.closeRoom(roomId);
+  }
 }

--- a/apps/media/src/room/room.service.ts
+++ b/apps/media/src/room/room.service.ts
@@ -41,4 +41,11 @@ export class RoomService {
       return roomId;
     }
   }
+
+  closeRoom(roomId: string) {
+    const room = this.getRoom(roomId);
+    room.close();
+    this.rooms.delete(roomId);
+    return roomId;
+  }
 }

--- a/apps/media/src/signaling/signaling.gateway.ts
+++ b/apps/media/src/signaling/signaling.gateway.ts
@@ -176,4 +176,10 @@ export class SignalingGateway implements OnGatewayDisconnect {
   ) {
     return this.mediasoupService.resumeConsumers(client.id, roomId, consumerIds);
   }
+
+  @SubscribeMessage(SOCKET_EVENTS.closeRoom)
+  closeMeetingRoom(@ConnectedSocket() client: Socket, @MessageBody('roomId') roomId: string) {
+    client.to(roomId).emit(SOCKET_EVENTS.roomClosed);
+    this.mediasoupService.closeRoom(roomId);
+  }
 }

--- a/apps/media/src/signaling/signaling.service.ts
+++ b/apps/media/src/signaling/signaling.service.ts
@@ -1,4 +1,0 @@
-import { Injectable } from '@nestjs/common';
-
-@Injectable()
-export class SignallingService {}


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat] {제목~~} -->
<!-- Reviewer, Assignees, Label 붙이기 -->

## 관련 이슈 번호

<!-- 이슈를 닫지 않는다면 이유 작성하기 -->

- close #348 

## 작업 내용
- 방 전체종료 요청 구현
- 방 종료 요청 시 `room-closed` EVENT 발송, 서버 메모리 정리

## PR 포인트

## 고민과 학습내용
- 서버에서 소켓연결을 강제로 끊는 것 보다 연결을 끊으라는 이벤트를 보내 클라이언트에서 소켓 연결을 종료하는 것이 일반적이라고 함
    - 클라이언트에서도 소켓 연결 해제 전 해야할 동작들이 있기 때문에 서버에서 연결을 직접적으로 해제하는것 보다 클라이언트에서 disconnect를 하는 것이 일반적이라고함.
  
## 스크린샷
- 테스트를 위해 간단하게 프론트 코드를 수정해서 테스트해봤습니다!
![화면 기록 2024-12-03 오전 12 04 45](https://github.com/user-attachments/assets/4287f642-340e-4e72-add1-b216e29ed8b0)
