### PR TITLE
[Feat] 발표자가 탭 닫기로 접속 종료 시에도 방폭되게 함

### DIFF
--- a/apps/media/src/mediasoup/mediasoup.service.ts
+++ b/apps/media/src/mediasoup/mediasoup.service.ts
@@ -48,7 +48,7 @@ export class MediasoupService implements OnModuleInit {
     return worker;
   }
 
-  async createRoom(roomId: string) {
+  async createRoom(roomId: string, masterSocketId: string) {
     const isExistRoom = this.roomService.existRoom(roomId);
     if (isExistRoom) {
       return roomId;
@@ -59,7 +59,7 @@ export class MediasoupService implements OnModuleInit {
       mediaCodecs: this.mediasoupConfig.router.mediaCodecs,
     });
 
-    return this.roomService.createRoom(roomId, router);
+    return this.roomService.createRoom(roomId, router, masterSocketId);
   }
 
   joinRoom(roomId: string, socketId: string, nickname: string) {

--- a/apps/media/src/record/record.service.ts
+++ b/apps/media/src/record/record.service.ts
@@ -117,7 +117,7 @@ export class RecordService {
       return;
     }
     this.releasePort(recordInfo.port);
-    recordInfo.stopRecordProcess();
+    recordInfo.clearStream();
     this.recordInfos.delete(roomId);
   }
 

--- a/apps/media/src/record/record.service.ts
+++ b/apps/media/src/record/record.service.ts
@@ -66,10 +66,6 @@ export class RecordService {
     return recordInfo;
   }
 
-  getRecordInfo(roomId: string) {
-    return this.recordInfos.get(roomId);
-  }
-
   private async addPlainTransport(recordInfo: RecordInfo, router: types.Router) {
     const plainTransport = await this.mediasoupService.createPlainTransport(router);
     recordInfo.setPlainTransport(plainTransport);

--- a/apps/media/src/record/recordInfo.ts
+++ b/apps/media/src/record/recordInfo.ts
@@ -43,7 +43,7 @@ export class RecordInfo {
     this.recordConsumer.resume();
   }
 
-  stopRecordProcess() {
+  clearStream() {
     if (this.recordConsumer) {
       this.recordConsumer.close();
       this.recordConsumer = null;
@@ -81,9 +81,10 @@ export class RecordInfo {
         console.log('FFmpeg error:1', err);
       })
       .on('end', () => {
-        this.ncpService.uploadFile(filePath, remoteFileName, roomId);
+        // this.ncpService.uploadFile(filePath, remoteFileName, roomId);
         unlinkSync(sdpFilePath);
         this.ffmpegProcess = null;
+        this.clearStream();
       })
       .save(filePath);
 

--- a/apps/media/src/room/room.service.ts
+++ b/apps/media/src/room/room.service.ts
@@ -31,14 +31,7 @@ export class RoomService {
 
   deletePeer(socketId: string) {
     for (const [roomId, room] of this.rooms) {
-      if (!room.removePeer(socketId)) continue;
-
-      if (room.peers.size === 0) {
-        room.close();
-        this.rooms.delete(roomId);
-      }
-
-      return roomId;
+      if (room.removePeer(socketId)) return roomId;
     }
   }
 
@@ -47,5 +40,13 @@ export class RoomService {
     room.close();
     this.rooms.delete(roomId);
     return roomId;
+  }
+
+  checkIsMaster(roomId: string, socketId: string) {
+    const room = this.rooms.get(roomId);
+    if (!room) {
+      return false;
+    }
+    return room.masterSocketId === socketId;
   }
 }

--- a/apps/media/src/room/room.service.ts
+++ b/apps/media/src/room/room.service.ts
@@ -11,8 +11,8 @@ export class RoomService {
 
   constructor() {}
 
-  createRoom(roomId: string, router: Router) {
-    const room = new Room(roomId, router);
+  createRoom(roomId: string, router: Router, masterSocketId: string) {
+    const room = new Room(roomId, router, masterSocketId);
     this.rooms.set(roomId, room);
     return roomId;
   }

--- a/apps/media/src/room/room.service.ts
+++ b/apps/media/src/room/room.service.ts
@@ -49,4 +49,20 @@ export class RoomService {
     }
     return room.masterSocketId === socketId;
   }
+
+  checkRoomIsOpen(roomId: string) {
+    const room = this.rooms.get(roomId);
+    if (!room) {
+      return false;
+    }
+    return room.isOpen;
+  }
+
+  setRoomIsOpen(roomId: string, isOpen: boolean) {
+    const room = this.rooms.get(roomId);
+    if (!room) {
+      return;
+    }
+    room.isOpen = isOpen;
+  }
 }

--- a/apps/media/src/room/room.ts
+++ b/apps/media/src/room/room.ts
@@ -6,12 +6,14 @@ import { Peer } from './peer';
 
 export class Room {
   id: string;
+  masterSocketId: string;
   router: Router;
   peers: Map<string, Peer>;
 
-  constructor(roomId: string, router: Router) {
+  constructor(roomId: string, router: Router, masterSocketId: string) {
     this.id = roomId;
     this.router = router;
+    this.masterSocketId = masterSocketId;
     this.peers = new Map();
   }
 

--- a/apps/media/src/room/room.ts
+++ b/apps/media/src/room/room.ts
@@ -9,12 +9,14 @@ export class Room {
   masterSocketId: string;
   router: Router;
   peers: Map<string, Peer>;
+  isOpen: boolean;
 
   constructor(roomId: string, router: Router, masterSocketId: string) {
     this.id = roomId;
     this.router = router;
     this.masterSocketId = masterSocketId;
     this.peers = new Map();
+    this.isOpen = true;
   }
 
   getRouter() {

--- a/apps/media/src/signaling/signaling.gateway.ts
+++ b/apps/media/src/signaling/signaling.gateway.ts
@@ -34,8 +34,8 @@ export class SignalingGateway implements OnGatewayDisconnect {
   @SubscribeMessage(SOCKET_EVENTS.joinRoom)
   joinRoom(@ConnectedSocket() client: Socket, @MessageBody() joinRoomDto: server.JoinRoomDto) {
     const { roomId, nickname } = joinRoomDto;
-    client.join(roomId);
     const rtpCapabilities = this.mediasoupService.joinRoom(roomId, client.id, nickname);
+    client.join(roomId);
     client.to(roomId).emit(SOCKET_EVENTS.newPeer, { peerId: client.id, nickname });
     return { rtpCapabilities };
   }
@@ -114,8 +114,8 @@ export class SignalingGateway implements OnGatewayDisconnect {
       return;
     }
 
-    const isExistRoom = this.roomService.existRoom(roomId);
-    if (isExistRoom) {
+    const isOpen = this.roomService.checkRoomIsOpen(roomId);
+    if (isOpen) {
       client.to(roomId).emit(SOCKET_EVENTS.peerLeft, { peerId: client.id });
     }
   }
@@ -196,6 +196,7 @@ export class SignalingGateway implements OnGatewayDisconnect {
   @SubscribeMessage(SOCKET_EVENTS.closeRoom)
   closeMeetingRoom(@ConnectedSocket() client: Socket, @MessageBody('roomId') roomId: string) {
     client.to(roomId).emit(SOCKET_EVENTS.roomClosed);
+    this.roomService.setRoomIsOpen(roomId, false);
   }
 
   @SubscribeMessage(SOCKET_EVENTS.startRecord)

--- a/apps/media/src/signaling/signaling.gateway.ts
+++ b/apps/media/src/signaling/signaling.gateway.ts
@@ -13,6 +13,7 @@ import type { client, server } from '@repo/mediasoup';
 
 import { MediasoupService } from '@/mediasoup/mediasoup.service';
 import { RecordService } from '@/record/record.service';
+import { RoomService } from '@/room/room.service';
 import { WSExceptionFilter } from '@/wsException.filter';
 
 @WebSocketGateway()
@@ -20,7 +21,8 @@ import { WSExceptionFilter } from '@/wsException.filter';
 export class SignalingGateway implements OnGatewayDisconnect {
   constructor(
     private mediasoupService: MediasoupService,
-    private recordService: RecordService
+    private recordService: RecordService,
+    private roomService: RoomService
   ) {}
 
   @SubscribeMessage(SOCKET_EVENTS.createRoom)
@@ -104,12 +106,18 @@ export class SignalingGateway implements OnGatewayDisconnect {
 
   handleDisconnect(@ConnectedSocket() client: Socket) {
     const roomId = this.mediasoupService.disconnect(client.id);
-    const recordInfo = this.recordService.getRecordInfo(roomId);
-    if (recordInfo && recordInfo.socketId === client.id) {
+    const isMaster = this.roomService.checkIsMaster(roomId, client.id);
+    if (isMaster) {
+      client.to(roomId).emit(SOCKET_EVENTS.roomClosed);
       this.recordService.stopRecord(roomId);
+      this.mediasoupService.closeRoom(roomId);
+      return;
     }
 
-    client.to(roomId).emit(SOCKET_EVENTS.peerLeft, { peerId: client.id });
+    const isExistRoom = this.roomService.existRoom(roomId);
+    if (isExistRoom) {
+      client.to(roomId).emit(SOCKET_EVENTS.peerLeft, { peerId: client.id });
+    }
   }
 
   @SubscribeMessage(SOCKET_EVENTS.closeProducer)
@@ -188,7 +196,6 @@ export class SignalingGateway implements OnGatewayDisconnect {
   @SubscribeMessage(SOCKET_EVENTS.closeRoom)
   closeMeetingRoom(@ConnectedSocket() client: Socket, @MessageBody('roomId') roomId: string) {
     client.to(roomId).emit(SOCKET_EVENTS.roomClosed);
-    this.mediasoupService.closeRoom(roomId);
   }
 
   @SubscribeMessage(SOCKET_EVENTS.startRecord)

--- a/apps/media/src/signaling/signaling.gateway.ts
+++ b/apps/media/src/signaling/signaling.gateway.ts
@@ -24,8 +24,8 @@ export class SignalingGateway implements OnGatewayDisconnect {
   ) {}
 
   @SubscribeMessage(SOCKET_EVENTS.createRoom)
-  async handleCreateRoom(@MessageBody('roomId') roomId: string) {
-    await this.mediasoupService.createRoom(roomId);
+  async handleCreateRoom(@ConnectedSocket() client: Socket, @MessageBody('roomId') roomId: string) {
+    await this.mediasoupService.createRoom(roomId, client.id);
     return { roomId };
   }
 

--- a/apps/media/src/signaling/signaling.module.ts
+++ b/apps/media/src/signaling/signaling.module.ts
@@ -2,11 +2,12 @@ import { Module } from '@nestjs/common';
 
 import { MediasoupModule } from '@/mediasoup/mediasoup.module';
 import { RecordModule } from '@/record/record.module';
+import { RoomModule } from '@/room/room.module';
 
 import { SignalingGateway } from './signaling.gateway';
 
 @Module({
-  imports: [MediasoupModule, RecordModule],
+  imports: [MediasoupModule, RecordModule, RoomModule],
   providers: [SignalingGateway],
   exports: [SignalingGateway],
 })


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat] {제목~~} -->
<!-- Reviewer, Assignees, Label 붙이기 -->

## 관련 이슈 번호

<!-- 이슈를 닫지 않는다면 이유 작성하기 -->

- close #385

## 작업 내용
- 탭닫기 또는 비정상적 종료를 하더라도 티클 강의실이 닫히게 함.

## PR 포인트
### 메모리 누수 해결
- 기존 코드에서는 `close-room` 이벤트 발생 시 roomService에서 room객체를 없에줌
- 그 후 peer disconnect 하면서 peer를 room에서 없에는 로직을 진행함
    - 앞에서 진행한 close-room의 헨들러에서 room객체가 없어진 상태
    - peer객체들도 비우기때문에 이미 비워져 있었어서 이곳에서는 메모리누수 x 
    - room 객체가 없기때문에 해당 peer가 속했던 방번호가 리턴되지 않음.
         - 방 번호가 리턴되어야 해당 방의 `recordInfo`객체를 삭제 가능 => `메모리 누수 발생`
         - 녹음 종료는 transport가 사라지면 stream이 끊겨 자동으로 됨.

- 기존의 코드는 room객체가 있어야 해당 방의 recordInfo 객체를 없엘 수 있었음.
```typescript
closeMeetingRoom(@ConnectedSocket() client: Socket, @MessageBody('roomId') roomId: string) {
    client.to(roomId).emit(SOCKET_EVENTS.roomClosed);
    this.mediasoupService.closeRoom(roomId); //1.먼저 삭제가 되기 떄문에
  }

handleDisconnect(@ConnectedSocket() client: Socket) {
    const roomId = this.mediasoupService.disconnect(client.id); //2. 룸 객체가 없어 roomId반환이 안되고
    const recordInfo = this.recordService.getRecordInfo(roomId);  // 3. 여기에서 객체를 찾을 수 없음 => 누수발생 
    if (recordInfo && recordInfo.socketId === client.id) {
      this.recordService.stopRecord(roomId);
    }
    client.to(roomId).emit(SOCKET_EVENTS.peerLeft, { peerId: client.id });
}
```
- 개선한 코드
```typescript
  closeMeetingRoom(@ConnectedSocket() client: Socket, @MessageBody('roomId') roomId: string) {
    client.to(roomId).emit(SOCKET_EVENTS.roomClosed);  // 종료 이벤트만 전송
  }

  handleDisconnect(@ConnectedSocket() client: Socket) {
    const roomId = this.mediasoupService.disconnect(client.id); //방 객체가 있어 정상적으로 roomId 반환
    const isMaster = this.roomService.checkIsMaster(roomId, client.id); // 방 객체에 마스터인지 체크
    if (isMaster) {
      client.to(roomId).emit(SOCKET_EVENTS.roomClosed); .//마스터가 종료되면 전체 종료
      this.recordService.stopRecord(roomId); // 녹화종료
      this.mediasoupService.closeRoom(roomId); // 방 닫기
      return;
    }

   const isOpen = this.roomService.checkRoomIsOpen(roomId);
    if (isOpen) {
      client.to(roomId).emit(SOCKET_EVENTS.peerLeft, { peerId: client.id });
    }
  }
```
- 방이 없어질 때 불필요한 이벤트를 줄이기 위해 조건문 추가.
- 방 상태에 대한 데이터를 room에 추가하여 현재 방 상태가 닫히거나 없으면 이벤트를 발송 안하게 함.
- peerLeft 이벤트 발송 시 close-consumer, 등 부수 이벤트가 많이 발생하기때문에 이벤트 최적화를 위해 조건문 추가
## 고민과 학습내용

## 스크린샷
![화면 기록 2024-12-05 오전 1 16 59](https://github.com/user-attachments/assets/23ead966-77c0-4daf-945e-c584d77728bc)