### PR TITLE
[Feat] 대시보드 조회시에 summary 여부 판단 추가

### DIFF
--- a/apps/api/src/dashboard/dashboard.module.ts
+++ b/apps/api/src/dashboard/dashboard.module.ts
@@ -2,13 +2,14 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { Applicant } from '@/entity/applicant.entity';
+import { Summary } from '@/entity/summary.entity';
 import { Ticle } from '@/entity/ticle.entity';
 
 import { DashboardController } from './dashboard.controller';
 import { DashboardService } from './dashboard.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Ticle, Applicant])],
+  imports: [TypeOrmModule.forFeature([Ticle, Applicant, Summary])],
   controllers: [DashboardController],
   providers: [DashboardService],
 })

--- a/apps/api/src/dashboard/dashboard.service.ts
+++ b/apps/api/src/dashboard/dashboard.service.ts
@@ -107,7 +107,7 @@ export class DashboardService {
 
     const ticles = applicants.map((applicant) => ({
       ...applicant.ticle,
-      summary: applicant.ticle.summary ? applicant.ticle.summary.id !== null : false, // summary 필드 안전하게 처리
+      summary: applicant.ticle.summary ? applicant.ticle.summary.id !== null : false,
     }));
 
     const totalPages = Math.ceil(totalItems / pageSize);


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat] {제목~~} -->
<!-- Reviewer, Assignees, Label 붙이기 -->

## 관련 이슈 번호

<!-- 이슈를 닫지 않는다면 이유 작성하기 -->

- close #374

## 작업 내용
- 대시보드 조회시에 summary의 여부를 true/fasle로 반환할 수 있도록 추가했습니다.
- 노션 API문서에 업데이트 해두었습니다.
## PR 포인트

## 고민과 학습내용

## 스크린샷
- 개설한 티클 대시보드
<img width="665" alt="image" src="https://github.com/user-attachments/assets/20b4d83c-8ef3-4dec-9b5f-570aef8c649c">

- 신청한 티클 대시보드
<img width="686" alt="image" src="https://github.com/user-attachments/assets/0cae4b9d-64b4-4777-a22a-d38bc0c3cabb">