### PR TITLE
[Feat] 대시보드 UI 수정, summary 여부에 따른 AI 요약 확인 버튼 분기

### DIFF
--- a/apps/web/src/components/dashboard/AiSummaryDialog.tsx
+++ b/apps/web/src/components/dashboard/AiSummaryDialog.tsx
@@ -13,10 +13,10 @@ function AiSummaryDialog({ isOpen, onClose, ticleId }: AiSummaryDialogProps) {
   const { data } = useAiSummary(ticleId);
 
   return (
-    <Dialog.Root isOpen={isOpen} onClose={onClose} className="h-[30rem] w-[35rem]">
+    <Dialog.Root isOpen={isOpen} onClose={onClose} className="flex h-[30rem] w-[35rem] flex-col">
       <Dialog.Title align="center">AI 음성 요약</Dialog.Title>
       <Dialog.Close onClose={onClose} />
-      <Dialog.Content className="custom-scrollbar overflow-y-scroll">
+      <Dialog.Content className="custom-scrollbar h-full overflow-y-scroll">
         {!data && (
           <div className="flex h-[20rem] w-full flex-col items-center justify-center gap-10">
             <Loading color="primary" />
@@ -25,15 +25,8 @@ function AiSummaryDialog({ isOpen, onClose, ticleId }: AiSummaryDialogProps) {
             </span>
           </div>
         )}
-        {data && !data.summaryText && (
-          <div className="flex h-[20rem] w-full flex-col items-center justify-center gap-10">
-            <span className="whitespace-pre text-center text-title1 text-primary">
-              AI 요약 결과가 없어요.
-            </span>
-          </div>
-        )}
         {data && data.summaryText && (
-          <p className="whitespace-pre text-body1">{data.summaryText}</p>
+          <p className="flex-1 whitespace-pre-wrap text-body1">{data.summaryText}</p>
         )}
       </Dialog.Content>
     </Dialog.Root>

--- a/apps/web/src/components/dashboard/AiSummaryDialog.tsx
+++ b/apps/web/src/components/dashboard/AiSummaryDialog.tsx
@@ -17,7 +17,7 @@ function AiSummaryDialog({ isOpen, onClose, ticleId }: AiSummaryDialogProps) {
       <Dialog.Title align="center">AI 음성 요약</Dialog.Title>
       <Dialog.Close onClose={onClose} />
       <Dialog.Content className="custom-scrollbar h-full overflow-y-scroll">
-        {!data && (
+        {!data?.summaryText && (
           <div className="flex h-[20rem] w-full flex-col items-center justify-center gap-10">
             <Loading color="primary" />
             <span className="whitespace-pre text-center text-title1 text-primary">

--- a/apps/web/src/components/dashboard/apply/TicleInfoCard.tsx
+++ b/apps/web/src/components/dashboard/apply/TicleInfoCard.tsx
@@ -15,6 +15,7 @@ interface TicleInfoCardProps {
   startTime: string;
   endTime: string;
   status: 'closed' | 'open' | 'inProgress';
+  isSummaryExist: boolean;
 }
 
 function TicleInfoCard({
@@ -24,6 +25,7 @@ function TicleInfoCard({
   startTime,
   endTime,
   status,
+  isSummaryExist,
 }: TicleInfoCardProps) {
   const { isOpen, onOpen, onClose } = useModal();
   const { dateStr, timeRangeStr } = formatDateTimeRange(startTime, endTime);
@@ -59,7 +61,7 @@ function TicleInfoCard({
           </div>
         </div>
         <div className="flex gap-9">
-          {status === 'closed' && (
+          {status === 'closed' && isSummaryExist && (
             <button
               className="flex items-center gap-2 rounded-md p-2.5 hover:bg-teritary"
               onClick={handleAiSummaryDialogOpen}

--- a/apps/web/src/components/dashboard/apply/index.tsx
+++ b/apps/web/src/components/dashboard/apply/index.tsx
@@ -66,6 +66,7 @@ function Apply() {
                     startTime={ticle.startTime}
                     endTime={ticle.endTime}
                     status={ticle.ticleStatus}
+                    isSummaryExist={ticle.summary}
                   />
                 ))}
               </Fragment>

--- a/apps/web/src/components/dashboard/open/TicleInfoCard.tsx
+++ b/apps/web/src/components/dashboard/open/TicleInfoCard.tsx
@@ -17,9 +17,17 @@ interface TicleInfoCardProps {
   startTime: string;
   endTime: string;
   status: 'closed' | 'open' | 'inProgress';
+  isSummaryExist: boolean;
 }
 
-function TicleInfoCard({ ticleId, ticleTitle, startTime, endTime, status }: TicleInfoCardProps) {
+function TicleInfoCard({
+  ticleId,
+  ticleTitle,
+  startTime,
+  endTime,
+  status,
+  isSummaryExist,
+}: TicleInfoCardProps) {
   const {
     isOpen: isApplicantsDialogOpen,
     onOpen: onApplicantsDialogOpen,
@@ -72,7 +80,7 @@ function TicleInfoCard({ ticleId, ticleTitle, startTime, endTime, status }: Ticl
           </div>
         </div>
         <div className="flex gap-9">
-          {status === 'closed' && (
+          {status === 'closed' && isSummaryExist && (
             <button
               className="flex items-center gap-2 rounded-md p-2.5 hover:bg-teritary"
               onClick={handleAiSummaryDialogOpen}

--- a/apps/web/src/components/dashboard/open/index.tsx
+++ b/apps/web/src/components/dashboard/open/index.tsx
@@ -64,6 +64,7 @@ function Open() {
                   startTime={ticle.startTime}
                   endTime={ticle.endTime}
                   status={ticle.ticleStatus}
+                  isSummaryExist={ticle.summary}
                 />
               ))}
             </Fragment>

--- a/packages/types/src/dashboard/getDashboardList.ts
+++ b/packages/types/src/dashboard/getDashboardList.ts
@@ -36,6 +36,7 @@ const BaseDashboardResponseSchema = z.object({
   startTime: z.string().datetime(),
   endTime: z.string().datetime(),
   ticleStatus: z.enum([TicleStatus.CLOSED, TicleStatus.OPEN, TicleStatus.IN_PROGRESS]),
+  summary: z.boolean(),
 });
 
 const AppliedTicleSchema = BaseDashboardResponseSchema.extend({


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat] {제목~~} -->
<!-- Reviewer, Assignees, Label 붙이기 -->

## 관련 이슈 번호

<!-- 이슈를 닫지 않는다면 이유 작성하기 -->

- close #368 

## 작업 내용

- AI 요약 다이얼로그 UI 깨짐 해결
- summary가 존재할 때만 AI 요약 버튼 보이게 하기

## PR 포인트

## 고민과 학습내용

## 스크린샷

### 요약을 진행하지 않았다면 대시보드에서 AI 요약 버튼이 보이지 않음
<img width="1792" alt="image" src="https://github.com/user-attachments/assets/1d28ade4-21a7-42bf-9ea2-92789da745c3">

### 스크롤을 넘어서 보이던 문제 해결
<img width="1792" alt="image" src="https://github.com/user-attachments/assets/ee91082c-a71d-460f-9314-1ec962e40288">


